### PR TITLE
feat: add basic setup for the http api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["src/vmm"]
+members = [ "src/api","src/vmm"]
 resolver = "2"

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "api"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+actix-web = "4.5.1"
+serde = "1.0.197"

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1,0 +1,47 @@
+# API
+
+You can run the API with the following command:
+
+```bash
+cargo run
+``` 
+
+## Endpoints
+
+### POST endpoints: 
+
+
+#### `POST` /configuration
+To create a new configuration, you can send a POST request to the `/configuration` endpoint with the following body:
+
+<!-- TODO -->
+
+#### `POST` /run
+To run a vm with a configuration, you can send a POST request to the `/run` endpoint with the following body:
+
+```json
+{
+    "id": "vm-id"
+}
+```
+
+#### `POST` /shutdown
+
+To shutdown a vm, you can send a POST request to the `/shutdown` endpoint with the following body:
+
+```json
+{
+    "id": "vm-id"
+}
+```
+
+### GET ENDPOINTS:
+
+#### `GET` /logs/{id}
+
+To get the logs of a vm, you can send a GET request to the `/logs/{id}` endpoint.
+
+#### `GET` /metrics/{id}
+
+To get the metrics of a vm, you can send a GET request to the `/metrics/{id}` endpoint.
+

--- a/src/api/src/lib.rs
+++ b/src/api/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod services;

--- a/src/api/src/main.rs
+++ b/src/api/src/main.rs
@@ -1,0 +1,21 @@
+use actix_web::{App, HttpServer};
+use api::services::{configuration, logs, metrics, run, shutdown};
+
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    let port = 3000;
+
+    println!("Starting server on port:  {}", port);
+    HttpServer::new(|| {
+        App::new()
+            .service(configuration)
+            .service(run)
+            .service(logs)
+            .service(metrics)
+            .service(shutdown)
+    })
+    .bind(("127.0.0.1", port))?
+    .run()
+    .await
+}

--- a/src/api/src/main.rs
+++ b/src/api/src/main.rs
@@ -1,7 +1,6 @@
 use actix_web::{App, HttpServer};
 use api::services::{configuration, logs, metrics, run, shutdown};
 
-
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     let port = 3000;

--- a/src/api/src/services.rs
+++ b/src/api/src/services.rs
@@ -1,0 +1,32 @@
+use actix_web::{get, post, web, HttpResponse, Responder};
+
+#[post("/configuration")]
+pub async fn configuration(req_body: String) -> impl Responder {
+    // TODO: Use the body to create the vm configuration
+    HttpResponse::Ok().body(req_body)
+}
+
+#[post("/run")]
+pub async fn run(req_body: String) -> impl Responder {
+    // TODO: Use the body id to start the fm
+    HttpResponse::Ok().body(req_body)
+}
+
+#[get("/logs/{id}")]
+pub async fn logs(id: web::Path<String>) -> HttpResponse {
+    // TODO: maybe not close the stream and keep sending the logs
+    HttpResponse::Ok().body(format!("Logs here: {}", &id))
+}
+
+#[get("/metrics/{id}")]
+pub async fn metrics(id: web::Path<String>) -> HttpResponse {
+    // TODO: Get the metrics for a VM with the given ID
+
+    HttpResponse::Ok().body(format!("Metrics here: {}", &id))
+}
+
+#[post("/shutdown")]
+pub async fn shutdown(req_body: String) -> impl Responder {
+    // TODO: Get the id from the body and shutdown the vm
+    HttpResponse::Ok().body(req_body)
+}


### PR DESCRIPTION
# What does this pr do

This pr adds a basic setup for the HTTP endpoints with actix-web.


## Endpoints

### POST endpoints: 


#### `POST` /configuration
To create a new configuration, you can send a POST request to the `/configuration` endpoint with the following body:

<!-- TODO -->

#### `POST` /run
To run a vm with a configuration, you can send a POST request to the `/run` endpoint with the following body:

```json
{
    "id": "vm-id"
}
```

#### `POST` /shutdown

To shutdown a vm, you can send a POST request to the `/shutdown` endpoint with the following body:

```json
{
    "id": "vm-id"
}
```

### GET ENDPOINTS:

#### `GET` /logs/{id}

To get the logs of a vm, you can send a GET request to the `/logs/{id}` endpoint.

#### `GET` /metrics/{id}

To get the metrics of a vm, you can send a GET request to the `/metrics/{id}` endpoint.
