### PR TITLE
feat(CLI): implement reading of code and env files from config path and call "run" endpoint 

### DIFF
--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -13,3 +13,4 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_yaml = "0.9.34"
 schemars = "0.8.16"
 serde_json = "1.0.115"
+reqwest = "0.12.3"

--- a/src/cli/config/config.template.yaml
+++ b/src/cli/config/config.template.yaml
@@ -1,4 +1,4 @@
 language: rust
-env_path: .env
-code_path: src
+env_path: /home/charley/polytech/cloudlet/src/cli/config/example.env
+code_path: /home/charley/polytech/cloudlet/src/cli/src/main.rs
 log_level: debug

--- a/src/cli/config/config.template.yaml
+++ b/src/cli/config/config.template.yaml
@@ -1,4 +1,4 @@
 language: rust
-env_path: /home/charley/polytech/cloudlet/src/cli/config/example.env
-code_path: /home/charley/polytech/cloudlet/src/cli/src/main.rs
+env_path: /path/cloudlet/src/cli/config/example.env
+code_path: /path/cloudlet/src/cli/src/main.rs
 log_level: debug

--- a/src/cli/config/example.env
+++ b/src/cli/config/example.env
@@ -1,0 +1,3 @@
+HOST="localhost"
+PORT=3000
+PASSWORD=3456

--- a/src/cli/src/args.rs
+++ b/src/cli/src/args.rs
@@ -1,0 +1,17 @@
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct CliArgs {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Parser, Debug)]
+pub enum Commands {
+    Run {
+        #[arg(short, long)]
+        config_path: PathBuf,
+    },
+}

--- a/src/cli/src/request.rs
+++ b/src/cli/src/request.rs
@@ -1,0 +1,41 @@
+use crate::types::{Language, LogLevel};
+use reqwest::Client;
+use serde::Serialize;
+use std::error::Error;
+
+#[derive(Serialize, Debug)]
+pub struct HttpRunRequest {
+    pub language: Language,
+    pub env_content: String,
+    pub code_content: String,
+    pub log_level: LogLevel,
+}
+
+impl HttpRunRequest {
+    pub fn new(
+        language: Language,
+        env_content: String,
+        code_content: String,
+        log_level: LogLevel,
+    ) -> Self {
+        HttpRunRequest {
+            language,
+            env_content,
+            code_content,
+            log_level,
+        }
+    }
+}
+
+pub async fn run_request(request: HttpRunRequest) -> Result<(), Box<dyn Error>> {
+    let client = Client::new();
+    let res = client
+        .post("http://127.0.0.1:3000/run")
+        .body(serde_json::to_string(&request)?)
+        .send()
+        .await?;
+    println!("Response Status: {}", res.status());
+    let body = res.text().await?;
+    println!("Response body: {}", body);
+    Ok(())
+}

--- a/src/cli/src/types.rs
+++ b/src/cli/src/types.rs
@@ -1,7 +1,7 @@
 use clap::ValueEnum;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, ValueEnum, Deserialize)]
+#[derive(Clone, Debug, ValueEnum, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Language {
     Rust,
@@ -9,7 +9,7 @@ pub enum Language {
     Node,
 }
 
-#[derive(Clone, Debug, ValueEnum, Deserialize)]
+#[derive(Clone, Debug, ValueEnum, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LogLevel {
     Debug,

--- a/src/cli/src/utils.rs
+++ b/src/cli/src/utils.rs
@@ -1,11 +1,20 @@
 use crate::types::Config;
 use std::fs::File;
 use std::io::{self, Read};
+use std::path::PathBuf;
 
-pub fn load_config(config_path: &str) -> io::Result<Config> {
+pub fn load_config(config_path: &PathBuf) -> io::Result<Config> {
     let mut file = File::open(config_path)?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
-    let config: Config = serde_yaml::from_str(&contents).unwrap();
+    let config: Config = serde_yaml::from_str(&contents)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     Ok(config)
+}
+
+pub fn read_file(file_path: &str) -> io::Result<String> {
+    let mut file = File::open(file_path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    Ok(contents)
 }


### PR DESCRIPTION
## Description 

This pull request aims to implement a feature for reading files based on the "code_path" and "env_path" arguments (config-path). After reading these files (if they exist), the CLI sends a JSON object to the HTTP API at the "run" endpoint with a JSON body containing the code and environment file. It also implements small code refactor of CLI arguments.

## How to test this feature 

To test this feature, you need to start the HTTP API first:

From `src/api` : run cargo run
From `src/cli`:   run cargo run -- run --config-path=/path/file