### PR TITLE
feat(vmm): add another serial port dedicated to the serverless protocol

### DIFF
--- a/src/vmm/src/core/devices/serial.rs
+++ b/src/vmm/src/core/devices/serial.rs
@@ -10,6 +10,9 @@ use vmm_sys_util::eventfd::EventFd;
 pub const SERIAL_PORT_BASE: u16 = 0x3f8;
 pub const SERIAL_PORT_LAST_REGISTER: u16 = SERIAL_PORT_BASE + 0x8;
 
+pub const CONTROL_SERIAL_PORT: u16 = 0x2f8;
+pub const CONTROL_SERIAL_PORT_LAST_REGISTER: u16 = CONTROL_SERIAL_PORT + 0x8;
+
 pub struct EventFdTrigger(EventFd);
 
 impl Trigger for EventFdTrigger {


### PR DESCRIPTION
Adds another serial port to the vm.

The serial port is destined to be used to send and receive messages from the vm.

Note that the kernel used to run the vm needs to be configured to probe for that new serial, hence you need to enable those flags when compiling it:

```properties
CONFIG_SERIAL_8250_NR_UARTS=2
CONFIG_SERIAL_8250_RUNTIME_UARTS=2
```