### PR TITLE
feat(vmm): add a second serial device and attach a PTY to it

### DIFF
--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -18,6 +18,8 @@ kvm-ioctls = "0.16.0"
 libc = "0.2.153"
 linux-loader = { version = "0.11.0", features = ["bzimage", "elf"] }
 log = "0.4.20"
+nix = { version = "0.28.0", features = ["term"] }
+openpty = "0.2.0"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 virtio-bindings = "0.2.2"

--- a/src/vmm/src/core/devices/mod.rs
+++ b/src/vmm/src/core/devices/mod.rs
@@ -1,3 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::io;
+
 pub(crate) mod serial;
+
+#[derive(Debug)]
+/// Devices errors.
+pub enum Error {
+    // Event FD creation error
+    EventFdCreation(io::Error),
+    // Event FD clone error
+    EventFdClone(io::Error),
+    // Serial raw bytes enqueueing error
+    SerialEnqueue(vm_superio::serial::Error<io::Error>),
+}
+
+/// Dedicated [`Result`](https://doc.rust-lang.org/std/result/) type.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/vmm/src/core/devices/serial.rs
+++ b/src/vmm/src/core/devices/serial.rs
@@ -10,6 +10,9 @@ use vmm_sys_util::eventfd::EventFd;
 pub const SERIAL_PORT_BASE: u16 = 0x3f8;
 pub const SERIAL_PORT_LAST_REGISTER: u16 = SERIAL_PORT_BASE + 0x8;
 
+pub const SERIAL2_PORT_BASE: u16 = 0x2f8;
+pub const SERIAL2_PORT_LAST_REGISTER: u16 = SERIAL2_PORT_BASE + 0x8;
+
 pub struct EventFdTrigger(EventFd);
 
 impl Trigger for EventFdTrigger {

--- a/src/vmm/src/core/devices/serial.rs
+++ b/src/vmm/src/core/devices/serial.rs
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::io::{stdout, Error, Result, Stdout};
+use std::cmp;
+use std::collections::VecDeque;
+use std::io::{self, Write};
 use std::ops::Deref;
+use std::sync::Arc;
 
-use vm_superio::serial::NoEvents;
+use super::{Error, Result};
+
+use vm_superio::serial::SerialEvents;
 use vm_superio::{Serial, Trigger};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -16,9 +21,9 @@ pub const SERIAL2_PORT_LAST_REGISTER: u16 = SERIAL2_PORT_BASE + 0x8;
 pub struct EventFdTrigger(EventFd);
 
 impl Trigger for EventFdTrigger {
-    type E = Error;
+    type E = io::Error;
 
-    fn trigger(&self) -> Result<()> {
+    fn trigger(&self) -> io::Result<()> {
         self.write(1)
     }
 }
@@ -31,33 +36,95 @@ impl Deref for EventFdTrigger {
 }
 
 impl EventFdTrigger {
-    pub fn new(flag: i32) -> Result<Self> {
+    pub fn new(flag: i32) -> io::Result<Self> {
         Ok(EventFdTrigger(EventFd::new(flag)?))
     }
-    pub fn try_clone(&self) -> Result<Self> {
+    pub fn try_clone(&self) -> io::Result<Self> {
         Ok(EventFdTrigger((**self).try_clone()?))
     }
 }
 
-pub(crate) struct LumperSerial {
+pub(crate) struct LumperSerial<W: Write> {
     // evenfd allows for the device to send interrupts to the guest.
     eventfd: EventFdTrigger,
 
     // serial is the actual serial device.
-    pub serial: Serial<EventFdTrigger, NoEvents, Stdout>,
+    pub serial: Serial<EventFdTrigger, LumperSerialEvents, W>,
+
+    in_buffer: VecDeque<u8>,
+    in_buffer_empty_eventfd: Arc<EventFd>,
 }
 
-impl LumperSerial {
-    pub fn new() -> Result<Self> {
+impl<W: Write> LumperSerial<W> {
+    pub fn new(out: W) -> Result<Self> {
         let eventfd = EventFdTrigger::new(libc::EFD_NONBLOCK).unwrap();
+        let in_buffer_empty_eventfd =
+            Arc::new(EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFdCreation)?);
+        let events: LumperSerialEvents = LumperSerialEvents::new(in_buffer_empty_eventfd.clone());
 
         Ok(LumperSerial {
-            eventfd: eventfd.try_clone()?,
-            serial: Serial::new(eventfd.try_clone()?, stdout()),
+            eventfd: eventfd.try_clone().map_err(Error::EventFdClone)?,
+            serial: Serial::with_events(
+                eventfd.try_clone().map_err(Error::EventFdClone)?,
+                events,
+                out,
+            ),
+            in_buffer: VecDeque::new(),
+            in_buffer_empty_eventfd,
         })
     }
 
     pub fn eventfd(&self) -> Result<EventFd> {
-        Ok(self.eventfd.try_clone()?.0)
+        Ok(self.eventfd.try_clone().map_err(Error::EventFdClone)?.0)
+    }
+
+    pub fn enqueue_raw_bytes(&mut self, input: &[u8]) -> Result<()> {
+        self.in_buffer.extend(input);
+        self.flush_in_buffer()
+    }
+
+    pub fn flush_in_buffer(&mut self) -> Result<()> {
+        let fifo_capacity = self.serial.fifo_capacity();
+
+        if fifo_capacity > 0 {
+            let drained = self
+                .in_buffer
+                .drain(..cmp::min(self.in_buffer.len(), fifo_capacity))
+                .collect::<Vec<u8>>();
+
+            self.serial
+                .enqueue_raw_bytes(&drained)
+                .map_err(Error::SerialEnqueue)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn in_buffer_empty_eventfd(&self) -> &EventFd {
+        &self.in_buffer_empty_eventfd
+    }
+}
+
+pub(crate) struct LumperSerialEvents {
+    in_buffer_empty_eventfd: Arc<EventFd>,
+}
+
+impl LumperSerialEvents {
+    pub fn new(in_buffer_empty_eventfd: Arc<EventFd>) -> Self {
+        Self {
+            in_buffer_empty_eventfd,
+        }
+    }
+}
+
+impl SerialEvents for LumperSerialEvents {
+    fn buffer_read(&self) {}
+
+    fn out_byte(&self) {}
+
+    fn tx_lost_byte(&self) {}
+
+    fn in_buffer_empty(&self) {
+        self.in_buffer_empty_eventfd.write(1).unwrap();
     }
 }

--- a/src/vmm/src/core/epoll_context.rs
+++ b/src/vmm/src/core/epoll_context.rs
@@ -6,6 +6,8 @@ use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::result;
 
+use epoll::Events;
+
 pub(crate) const EPOLL_EVENTS_LEN: usize = 10;
 
 pub struct EpollContext {
@@ -19,11 +21,15 @@ impl EpollContext {
     }
 
     pub fn add_stdin(&self) -> result::Result<(), io::Error> {
+        self.add_fd(libc::STDIN_FILENO, epoll::Events::EPOLLIN)
+    }
+
+    pub fn add_fd(&self, fd: RawFd, event: Events) -> result::Result<(), io::Error> {
         epoll::ctl(
             self.raw_fd,
             epoll::ControlOptions::EPOLL_CTL_ADD,
-            libc::STDIN_FILENO,
-            epoll::Event::new(epoll::Events::EPOLLIN, libc::STDIN_FILENO as u64),
+            fd,
+            epoll::Event::new(event, fd as u64),
         )?;
 
         Ok(())

--- a/src/vmm/src/core/mod.rs
+++ b/src/vmm/src/core/mod.rs
@@ -15,10 +15,10 @@ mod devices;
 mod epoll_context;
 mod kernel;
 mod network;
+mod slip_pty;
 pub mod vmm;
 
 #[derive(Debug)]
-
 /// VMM errors.
 pub enum Error {
     /// Failed to write boot parameters to guest memory.
@@ -42,19 +42,29 @@ pub enum Error {
     /// Memory error.
     Memory(vm_memory::Error),
     /// Serial creation error
-    SerialCreation(io::Error),
+    SerialCreation(devices::Error),
+    /// PTY creation error
+    PtyCreation,
+    /// PTY set up error
+    PtySetup,
     /// IRQ registration error
-    IrqRegister(io::Error),
+    IrqRegister(devices::Error),
     /// epoll creation error
     EpollError(io::Error),
     /// STDIN read error
     StdinRead(kvm_ioctls::Error),
     /// STDIN write error
     StdinWrite(vm_superio::serial::Error<io::Error>),
+    /// PTY read error
+    PtyRead(io::Error),
+    /// PTY serial write error
+    PtySerialWrite(vm_superio::serial::Error<io::Error>),
     /// Terminal configuration error
     TerminalConfigure(kvm_ioctls::Error),
     // Tap open error
     OpenTap(open_tap::Error),
+    // PTY write error
+    PtyRx(devices::Error),
 }
 
 /// Dedicated [`Result`](https://doc.rust-lang.org/std/result/) type.

--- a/src/vmm/src/core/slip_pty.rs
+++ b/src/vmm/src/core/slip_pty.rs
@@ -1,0 +1,60 @@
+use std::{
+    fs::File,
+    io::Read,
+    os::fd::{AsRawFd, RawFd},
+    sync::Arc,
+};
+
+use nix::sys::termios;
+use tracing::info;
+
+use super::{devices::serial::LumperSerial, Error, Result};
+
+pub struct SlipPty {
+    serial: LumperSerial<Arc<File>>,
+    master: Arc<File>,
+}
+
+impl SlipPty {
+    pub fn new() -> Result<Self> {
+        // Open a new PTY
+        let (master, _, name) =
+            openpty::openpty(None, None, None).map_err(|_| Error::PtyCreation)?;
+        info!(?name, "Opened PTY for SLIP");
+
+        // Disable echo in the master end
+        let mut termios = termios::tcgetattr(&master).map_err(|_| Error::PtySetup)?;
+        termios.local_flags.remove(termios::LocalFlags::ECHO);
+        termios::tcsetattr(&master, termios::SetArg::TCSANOW, &termios)
+            .map_err(|_| Error::PtySetup)?;
+
+        // Create a new Serial device around this PTY
+        let master = Arc::new(master);
+        let serial = LumperSerial::new(master.clone()).map_err(Error::SerialCreation)?;
+
+        Ok(Self {
+            serial,
+            master: master.clone(),
+        })
+    }
+
+    pub fn serial(&self) -> &LumperSerial<Arc<File>> {
+        &self.serial
+    }
+
+    pub fn serial_mut(&mut self) -> &mut LumperSerial<Arc<File>> {
+        &mut self.serial
+    }
+
+    pub fn pty_master_fd(&self) -> RawFd {
+        self.master.as_raw_fd()
+    }
+
+    pub fn handle_master_rx(&mut self) -> Result<()> {
+        let mut out = [0u8; 1500];
+        let count = self.master.read(&mut out).map_err(Error::PtyRead)?;
+        self.serial
+            .enqueue_raw_bytes(&out[..count])
+            .map_err(Error::PtyRx)
+    }
+}

--- a/src/vmm/src/core/vmm.rs
+++ b/src/vmm/src/core/vmm.rs
@@ -8,7 +8,7 @@ use crate::core::{Error, Result};
 use kvm_bindings::{kvm_userspace_memory_region, KVM_MAX_CPUID_ENTRIES};
 use kvm_ioctls::{Kvm, VmFd};
 use linux_loader::loader::KernelLoaderResult;
-use std::io;
+use std::io::{self, stdout, Stdout};
 use std::net::Ipv4Addr;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::prelude::RawFd;
@@ -21,6 +21,7 @@ use vmm_sys_util::terminal::Terminal;
 
 use super::network::open_tap::open_tap;
 use super::network::tap::Tap;
+use super::slip_pty::SlipPty;
 
 pub struct VMM {
     vm_fd: VmFd,
@@ -29,8 +30,8 @@ pub struct VMM {
     vcpus: Vec<Vcpu>,
     _tap: Tap,
 
-    serial: Arc<Mutex<LumperSerial>>,
-    serial2: Arc<Mutex<LumperSerial>>,
+    serial: Arc<Mutex<LumperSerial<Stdout>>>,
+    slip_pty: Arc<Mutex<SlipPty>>,
     epoll: EpollContext,
 }
 
@@ -44,9 +45,6 @@ impl VMM {
         // KVM returns a file descriptor to the VM object.
         let vm_fd = kvm.create_vm().map_err(Error::KvmIoctl)?;
 
-        let epoll = EpollContext::new().map_err(Error::EpollError)?;
-        epoll.add_stdin().map_err(Error::EpollError)?;
-
         let tap = open_tap(
             None,
             Some(tap_ip_addr),
@@ -57,6 +55,23 @@ impl VMM {
         )
         .map_err(Error::OpenTap)?;
 
+        let slip_pty = SlipPty::new()?;
+
+        let epoll = EpollContext::new().map_err(Error::EpollError)?;
+        epoll.add_stdin().map_err(Error::EpollError)?;
+        epoll
+            .add_fd(
+                slip_pty.pty_master_fd(),
+                epoll::Events::EPOLLIN | epoll::Events::EPOLLET,
+            )
+            .map_err(Error::EpollError)?;
+        epoll
+            .add_fd(
+                slip_pty.serial().in_buffer_empty_eventfd().as_raw_fd(),
+                epoll::Events::EPOLLIN | epoll::Events::EPOLLET,
+            )
+            .map_err(Error::EpollError)?;
+
         let vmm = VMM {
             vm_fd,
             kvm,
@@ -64,11 +79,9 @@ impl VMM {
             vcpus: vec![],
             _tap: tap,
             serial: Arc::new(Mutex::new(
-                LumperSerial::new().map_err(Error::SerialCreation)?,
+                LumperSerial::new(stdout()).map_err(Error::SerialCreation)?,
             )),
-            serial2: Arc::new(Mutex::new(
-                LumperSerial::new().map_err(Error::SerialCreation)?,
-            )),
+            slip_pty: Arc::new(Mutex::new(slip_pty)),
             epoll,
         };
 
@@ -131,9 +144,10 @@ impl VMM {
         self.vm_fd
             .register_irqfd(
                 &self
-                    .serial2
+                    .slip_pty
                     .lock()
                     .unwrap()
+                    .serial()
                     .eventfd()
                     .map_err(Error::IrqRegister)?,
                 3,
@@ -157,7 +171,7 @@ impl VMM {
                 &self.vm_fd,
                 index.into(),
                 Arc::clone(&self.serial),
-                Arc::clone(&self.serial2),
+                Arc::clone(&self.slip_pty),
             )
             .map_err(Error::Vcpu)?;
 
@@ -213,6 +227,7 @@ impl VMM {
                 epoll::wait(epoll_fd, -1, &mut events[..]).map_err(Error::EpollError)?;
 
             for event in events.iter().take(num_events) {
+                let event_evts = epoll::Events::from_bits_truncate(event.events);
                 let event_data = event.data as RawFd;
 
                 if let libc::STDIN_FILENO = event_data {
@@ -226,6 +241,25 @@ impl VMM {
                         .serial
                         .enqueue_raw_bytes(&out[..count])
                         .map_err(Error::StdinWrite)?;
+                } else if event_evts.intersects(epoll::Events::EPOLLIN)
+                    && event_data == self.slip_pty.lock().unwrap().pty_master_fd()
+                {
+                    self.slip_pty.lock().unwrap().handle_master_rx()?;
+                } else if event_data
+                    == self
+                        .slip_pty
+                        .lock()
+                        .unwrap()
+                        .serial()
+                        .in_buffer_empty_eventfd()
+                        .as_raw_fd()
+                {
+                    self.slip_pty
+                        .lock()
+                        .unwrap()
+                        .serial_mut()
+                        .flush_in_buffer()
+                        .map_err(Error::PtyRx)?;
                 }
             }
         }

--- a/src/vmm/src/core/vmm.rs
+++ b/src/vmm/src/core/vmm.rs
@@ -30,6 +30,7 @@ pub struct VMM {
     _tap: Tap,
 
     serial: Arc<Mutex<LumperSerial>>,
+    serial2: Arc<Mutex<LumperSerial>>,
     epoll: EpollContext,
 }
 
@@ -63,6 +64,9 @@ impl VMM {
             vcpus: vec![],
             _tap: tap,
             serial: Arc::new(Mutex::new(
+                LumperSerial::new().map_err(Error::SerialCreation)?,
+            )),
+            serial2: Arc::new(Mutex::new(
                 LumperSerial::new().map_err(Error::SerialCreation)?,
             )),
             epoll,
@@ -124,6 +128,18 @@ impl VMM {
             )
             .map_err(Error::KvmIoctl)?;
 
+        self.vm_fd
+            .register_irqfd(
+                &self
+                    .serial2
+                    .lock()
+                    .unwrap()
+                    .eventfd()
+                    .map_err(Error::IrqRegister)?,
+                3,
+            )
+            .map_err(Error::KvmIoctl)?;
+
         Ok(())
     }
 
@@ -137,8 +153,13 @@ impl VMM {
             .map_err(Error::KvmIoctl)?;
 
         for index in 0..num_vcpus {
-            let vcpu = Vcpu::new(&self.vm_fd, index.into(), Arc::clone(&self.serial))
-                .map_err(Error::Vcpu)?;
+            let vcpu = Vcpu::new(
+                &self.vm_fd,
+                index.into(),
+                Arc::clone(&self.serial),
+                Arc::clone(&self.serial2),
+            )
+            .map_err(Error::Vcpu)?;
 
             // Set CPUID.
             let mut vcpu_cpuid = base_cpuid.clone();


### PR DESCRIPTION
# What does this PR do?

This adds the emulation of a second serial port (COM2, at IO address `0x2F8` and using IRQ 3).

Lumper now also allocates a PTY device on the host, and links it to this new serial port to allow serial communication between the host and the guest. This can be used for SLIP-based networking, using the configuration below.

## Configuration

### Kernel

Some parameters need to be set when compiling the kernel to enable (C)SLIP support and probe the second serial device.

```
CONFIG_SLIP: set to true
Linux Kernel Configuration
└─>Device Drivers
└─>Network device support
└─>SLIP (serial line) support

CONFIG_SLIP_COMPRESSED: set to true
Linux Kernel Configuration
└─>Device Drivers
└─>Network device support
└─>CSLIP compressed headers

CONFIG_SERIAL_8250_NR_UARTS: set to 2
Linux Kernel Configuration
└─>Device Drivers
└─>Character devices
└─>Serial drivers
└─>Maximum number of 8250/16550 serial ports

CONFIG_SERIAL_8250_RUNTIME_UARTS: set to 2
Linux Kernel Configuration
└─>Device Drivers
└─>Character devices
└─>Serial drivers
└─>Number of 8250/16550 serial ports to register at runtime
```

### Guest networking

To enable SLIP on the second serial port and configure a static IP address on the new interface:
```sh
slattach -L /dev/ttyS1&
ifconfig sl0 172.30.0.11 netmask 255.255.0.0 up
```

This will probably need to be in the `/init` file.

### Host networking

To enable SLIP on the allocated PTY and configure a static IP address on the new interface:
```sh
slattach -L /dev/pts/n&
ip a add 172.30.0.10/16 dev sl0
ip l set sl0 up
```

Note that you will need to replace `/dev/pts/n` with the correct path to the PTY that was allocated. This path is logged during the startup of the VMM.