### PR TITLE
Feat(api): add support grpc client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,7 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,linux,vim,intellij+all,rust,rust-analyzer,visualstudiocode
+
+# RooFs and Kernel  
+kernel/*
+rootfs/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = [ "src/api","src/vmm", "src/cli"]
+members = ["src/api", "src/vmm", "src/cli"]
 resolver = "2"

--- a/proto/vmm.proto
+++ b/proto/vmm.proto
@@ -4,24 +4,29 @@ package vmmorchestrator;
 
 enum Language {
   PYTHON = 0;
-  JAVASCRIPT = 1;
+  NODE = 1;
   RUST = 2;
 }
+
 enum LogLevel {
   DEBUG = 0;
   INFO = 1;
   WARN = 2;
   ERROR = 3;
 }
+
 service VmmService {
   rpc Run (RunVmmRequest) returns (RunVmmResponse);
-  
 }
+
 message RunVmmRequest {
+
   Language language = 1;
-  LogLevel log_level = 4;
   string code = 2;
   string env = 3;
+  LogLevel log_level = 4;
+
 }
+
 message RunVmmResponse {
 }

--- a/proto/vmm.proto
+++ b/proto/vmm.proto
@@ -7,24 +7,21 @@ enum Language {
   JAVASCRIPT = 1;
   RUST = 2;
 }
-
 enum LogLevel {
   DEBUG = 0;
   INFO = 1;
   WARN = 2;
   ERROR = 3;
 }
-
 service VmmService {
   rpc Run (RunVmmRequest) returns (RunVmmResponse);
+  
 }
-
 message RunVmmRequest {
   Language language = 1;
   LogLevel log_level = 4;
   string code = 2;
   string env = 3;
 }
-
 message RunVmmResponse {
 }

--- a/proto/vmm.proto
+++ b/proto/vmm.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package vmmorchestrator;
+
+enum Language {
+  PYTHON = 0;
+  JAVASCRIPT = 1;
+  RUST = 2;
+}
+
+enum LogLevel {
+  DEBUG = 0;
+  INFO = 1;
+  WARN = 2;
+  ERROR = 3;
+}
+
+service VmmService {
+  rpc Run (RunVmmRequest) returns (RunVmmResponse);
+}
+
+message RunVmmRequest {
+  Language language = 1;
+  LogLevel log_level = 4;
+  string code = 2;
+  string env = 3;
+}
+
+message RunVmmResponse {
+}

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -8,3 +8,8 @@ edition = "2021"
 [dependencies]
 actix-web = "4.5.1"
 serde = "1.0.197"
+tonic = "0.9"
+prost = "0.11"
+
+[build-dependencies]
+tonic-build = "0.9"

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -10,6 +10,7 @@ actix-web = "4.5.1"
 serde = "1.0.197"
 tonic = "0.9"
 prost = "0.11"
+shared_models = { path="../shared-models" }
 
 [build-dependencies]
 tonic-build = "0.9"

--- a/src/api/build.rs
+++ b/src/api/build.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::compile_protos("../../proto/vmm.proto")?;
+    Ok(())
+}

--- a/src/api/src/client.rs
+++ b/src/api/src/client.rs
@@ -1,5 +1,6 @@
 use tonic::transport::Channel;
 use vmmorchestrator::vmm_service_client::VmmServiceClient;
+use vmmorchestrator::{Language, LogLevel};
 
 pub mod vmmorchestrator {
     tonic::include_proto!("vmmorchestrator");
@@ -20,10 +21,10 @@ impl VmmClient {
 
     pub async fn run_vmm(&mut self) {
         let request = tonic::Request::new(vmmorchestrator::RunVmmRequest {
-            language: vmmorchestrator::Language::Rust as i32,
+            language: Language::Rust as i32,
             env: "fn main() { println!(\"Hello, World!\"); }".to_string(),
             code: "fn main() { println!(\"Hello, World!\"); }".to_string(),
-            log_level: vmmorchestrator::LogLevel::Info as i32,
+            log_level: LogLevel::Info as i32,
         });
 
         let response = self.client.run(request).await.unwrap();

--- a/src/api/src/client.rs
+++ b/src/api/src/client.rs
@@ -1,6 +1,5 @@
 use tonic::transport::Channel;
 use vmmorchestrator::vmm_service_client::VmmServiceClient;
-use vmmorchestrator::{Language, LogLevel};
 
 pub mod vmmorchestrator {
     tonic::include_proto!("vmmorchestrator");
@@ -19,14 +18,8 @@ impl VmmClient {
         Ok(VmmClient { client })
     }
 
-    pub async fn run_vmm(&mut self) {
-        let request = tonic::Request::new(vmmorchestrator::RunVmmRequest {
-            language: Language::Rust as i32,
-            env: "fn main() { println!(\"Hello, World!\"); }".to_string(),
-            code: "fn main() { println!(\"Hello, World!\"); }".to_string(),
-            log_level: LogLevel::Info as i32,
-        });
-
+    pub async fn run_vmm(&mut self, request: vmmorchestrator::RunVmmRequest) {
+        let request = tonic::Request::new(request);
         let response = self.client.run(request).await.unwrap();
         println!("RESPONSE={:?}", response);
     }

--- a/src/api/src/client.rs
+++ b/src/api/src/client.rs
@@ -1,0 +1,32 @@
+use tonic::transport::Channel;
+use vmmorchestrator::vmm_service_client::VmmServiceClient;
+
+pub mod vmmorchestrator {
+    tonic::include_proto!("vmmorchestrator");
+}
+
+pub struct VmmClient {
+    client: VmmServiceClient<Channel>,
+}
+
+impl VmmClient {
+    pub async fn new() -> Result<Self, tonic::transport::Error> {
+        let client = VmmServiceClient::connect("http://[::1]:50051")
+            .await
+            .expect("Failed to connect to VMM service");
+
+        Ok(VmmClient { client })
+    }
+
+    pub async fn run_vmm(&mut self) {
+        let request = tonic::Request::new(vmmorchestrator::RunVmmRequest {
+            language: vmmorchestrator::Language::Rust as i32,
+            env: "fn main() { println!(\"Hello, World!\"); }".to_string(),
+            code: "fn main() { println!(\"Hello, World!\"); }".to_string(),
+            log_level: vmmorchestrator::LogLevel::Info as i32,
+        });
+
+        let response = self.client.run(request).await.unwrap();
+        println!("RESPONSE={:?}", response);
+    }
+}

--- a/src/api/src/lib.rs
+++ b/src/api/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod client;
 pub mod services;

--- a/src/api/src/main.rs
+++ b/src/api/src/main.rs
@@ -1,20 +1,13 @@
 use actix_web::{App, HttpServer};
-use api::services::{configuration, logs, metrics, run, shutdown};
+use api::services::{run, shutdown};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     let port = 3000;
 
     println!("Starting server on port:  {}", port);
-    HttpServer::new(|| {
-        App::new()
-            .service(configuration)
-            .service(run)
-            .service(logs)
-            .service(metrics)
-            .service(shutdown)
-    })
-    .bind(("127.0.0.1", port))?
-    .run()
-    .await
+    HttpServer::new(|| App::new().service(run).service(shutdown))
+        .bind(("127.0.0.1", port))?
+        .run()
+        .await
 }

--- a/src/api/src/services.rs
+++ b/src/api/src/services.rs
@@ -1,28 +1,18 @@
-use actix_web::{get, post, web, HttpResponse, Responder};
-
-#[post("/configuration")]
-pub async fn configuration(req_body: String) -> impl Responder {
-    // TODO: Use the body to create the vm configuration
-    HttpResponse::Ok().body(req_body)
-}
+use crate::client::VmmClient;
+use actix_web::{post, HttpResponse, Responder};
 
 #[post("/run")]
 pub async fn run(req_body: String) -> impl Responder {
-    // TODO: Use the body id to start the fm
-    HttpResponse::Ok().body(req_body)
-}
+    let grpc_client = VmmClient::new().await;
 
-#[get("/logs/{id}")]
-pub async fn logs(id: web::Path<String>) -> HttpResponse {
-    // TODO: maybe not close the stream and keep sending the logs
-    HttpResponse::Ok().body(format!("Logs here: {}", &id))
-}
-
-#[get("/metrics/{id}")]
-pub async fn metrics(id: web::Path<String>) -> HttpResponse {
-    // TODO: Get the metrics for a VM with the given ID
-
-    HttpResponse::Ok().body(format!("Metrics here: {}", &id))
+    match grpc_client {
+        Ok(mut client) => {
+            client.run_vmm().await;
+            HttpResponse::Ok().body(req_body)
+        }
+        Err(e) => HttpResponse::InternalServerError()
+            .body("Failed to connect to VMM service with error: ".to_string() + &e.to_string()),
+    }
 }
 
 #[post("/shutdown")]

--- a/src/api/src/services.rs
+++ b/src/api/src/services.rs
@@ -1,14 +1,25 @@
+use crate::client::vmmorchestrator::RunVmmRequest;
 use crate::client::VmmClient;
-use actix_web::{post, HttpResponse, Responder};
+use actix_web::{post, web, HttpResponse, Responder};
+use shared_models::CloudletDtoRequest;
 
 #[post("/run")]
-pub async fn run(req_body: String) -> impl Responder {
+pub async fn run(req_body: web::Json<CloudletDtoRequest>) -> impl Responder {
+    let req = req_body.into_inner();
     let grpc_client = VmmClient::new().await;
+
+    let vmm_request = RunVmmRequest {
+        code: req.code,
+        env: req.env,
+        language: req.language as i32,
+        log_level: req.log_level as i32,
+    };
 
     match grpc_client {
         Ok(mut client) => {
-            client.run_vmm().await;
-            HttpResponse::Ok().body(req_body)
+            println!("Successfully connected to VMM service");
+            client.run_vmm(vmm_request).await;
+            HttpResponse::Ok().body("Successfully ran VMM")
         }
         Err(e) => HttpResponse::InternalServerError()
             .body("Failed to connect to VMM service with error: ".to_string() + &e.to_string()),

--- a/src/cli/config/config.template.yaml
+++ b/src/cli/config/config.template.yaml
@@ -1,4 +1,4 @@
 language: rust
-env_path: /path/cloudlet/src/cli/config/example.env
-code_path: /path/cloudlet/src/cli/src/main.rs
+env_path: /home/charley/polytech/cloudlet/src/cli/config/example.env
+code_path: /home/charley/polytech/cloudlet/src/cli/src/main.rs
 log_level: debug

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -1,14 +1,14 @@
 use clap::Parser;
 
 use args::{CliArgs, Commands};
-use request::run_request;
-use request::HttpRunRequest;
+use services::run_request;
+use services::HttpRunRequest;
 use std::io::{self};
 use types::Config;
-use utils::{load_config, read_file};
+use utils::load_config;
 
 mod args;
-mod request;
+mod services;
 mod types;
 mod utils;
 
@@ -20,17 +20,7 @@ async fn main() -> io::Result<()> {
         Commands::Run { config_path } => {
             let yaml_config: Config =
                 load_config(&config_path).expect("Error while loading the configuration file");
-
-            let code =
-                read_file(&yaml_config.code_path).expect("Error while reading the code file");
-            println!("Code from file: \n{}", code);
-
-            let env =
-                read_file(&yaml_config.env_path).expect("Error while reading the environment file");
-            println!("Env from file : \n{}", env);
-            println!("Configuration from YAML file: \n {:#?}", yaml_config);
-
-            let body = HttpRunRequest::new(yaml_config.language, env, code, yaml_config.log_level);
+            let body = HttpRunRequest::new(yaml_config);
             let response = run_request(body).await;
 
             match response {

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -1,15 +1,14 @@
 use clap::Parser;
 
-use crate::types::YamlConfigFile;
 use args::{CliArgs, Commands};
+use shared_models::YamlClientConfigFile;
 
-use services::HttpVmmRequest;
+use services::CloudletClient;
 use std::io::{self};
-use utils::load_config;
+use utils::ConfigFileHandler;
 
 mod args;
 mod services;
-mod types;
 mod utils;
 
 #[tokio::main]
@@ -18,10 +17,10 @@ async fn main() -> io::Result<()> {
 
     match args.command {
         Commands::Run { config_path } => {
-            let yaml_config: YamlConfigFile =
-                load_config(&config_path).expect("Error while loading the configuration file");
-            let body = HttpVmmRequest::new(yaml_config);
-            let response = HttpVmmRequest::post(body).await;
+            let yaml_config: YamlClientConfigFile = ConfigFileHandler::load_config(&config_path)
+                .expect("Error while loading the configuration file");
+            let body = CloudletClient::new_cloudlet_config(yaml_config);
+            let response = CloudletClient::run(body).await;
 
             match response {
                 Ok(_) => println!("Request successful"),

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -1,10 +1,10 @@
 use clap::Parser;
 
+use crate::types::YamlConfigFile;
 use args::{CliArgs, Commands};
-use services::run_request;
-use services::HttpRunRequest;
+
+use services::HttpVmmRequest;
 use std::io::{self};
-use types::Config;
 use utils::load_config;
 
 mod args;
@@ -18,10 +18,10 @@ async fn main() -> io::Result<()> {
 
     match args.command {
         Commands::Run { config_path } => {
-            let yaml_config: Config =
+            let yaml_config: YamlConfigFile =
                 load_config(&config_path).expect("Error while loading the configuration file");
-            let body = HttpRunRequest::new(yaml_config);
-            let response = run_request(body).await;
+            let body = HttpVmmRequest::new(yaml_config);
+            let response = HttpVmmRequest::post(body).await;
 
             match response {
                 Ok(_) => println!("Request successful"),

--- a/src/cli/src/services.rs
+++ b/src/cli/src/services.rs
@@ -1,27 +1,28 @@
-use crate::types::{Language, LogLevel};
+use crate::types::{Config, Language, LogLevel};
+use crate::utils::read_file;
 use reqwest::Client;
 use serde::Serialize;
 use std::error::Error;
 
+
 #[derive(Serialize, Debug)]
 pub struct HttpRunRequest {
     pub language: Language,
-    pub env_content: String,
-    pub code_content: String,
+    pub env: String,
+    pub code: String,
     pub log_level: LogLevel,
 }
 
 impl HttpRunRequest {
-    pub fn new(
-        language: Language,
-        env_content: String,
-        code_content: String,
-        log_level: LogLevel,
-    ) -> Self {
+    pub fn new(config: Config) -> Self {
+        let code: String = read_file(&config.code_path).expect("Error while reading the code file");
+        let env = read_file(&config.env_path).expect("Error while reading the environment file");
+        let language = config.language;
+        let log_level = config.log_level;
         HttpRunRequest {
             language,
-            env_content,
-            code_content,
+            env,
+            code,
             log_level,
         }
     }

--- a/src/cli/src/services.rs
+++ b/src/cli/src/services.rs
@@ -1,42 +1,40 @@
-use crate::types::{Config, Language, LogLevel};
+use crate::types::{Language, LogLevel, YamlConfigFile};
 use crate::utils::read_file;
 use reqwest::Client;
 use serde::Serialize;
 use std::error::Error;
-
-
 #[derive(Serialize, Debug)]
-pub struct HttpRunRequest {
+pub struct HttpVmmRequest {
     pub language: Language,
     pub env: String,
     pub code: String,
     pub log_level: LogLevel,
 }
 
-impl HttpRunRequest {
-    pub fn new(config: Config) -> Self {
+impl HttpVmmRequest {
+    pub fn new(config: YamlConfigFile) -> Self {
         let code: String = read_file(&config.code_path).expect("Error while reading the code file");
         let env = read_file(&config.env_path).expect("Error while reading the environment file");
         let language = config.language;
         let log_level = config.log_level;
-        HttpRunRequest {
+        HttpVmmRequest {
             language,
             env,
             code,
             log_level,
         }
     }
-}
 
-pub async fn run_request(request: HttpRunRequest) -> Result<(), Box<dyn Error>> {
-    let client = Client::new();
-    let res = client
-        .post("http://127.0.0.1:3000/run")
-        .body(serde_json::to_string(&request)?)
-        .send()
-        .await?;
-    println!("Response Status: {}", res.status());
-    let body = res.text().await?;
-    println!("Response body: {}", body);
-    Ok(())
+    pub async fn post(request: HttpVmmRequest) -> Result<(), Box<dyn Error>> {
+        let client = Client::new();
+        let res = client
+            .post("http://127.0.0.1:3000/run")
+            .body(serde_json::to_string(&request)?)
+            .send()
+            .await?;
+        println!("Response Status: {}", res.status());
+        let body = res.text().await?;
+        println!("Response body: {}", body);
+        Ok(())
+    }
 }

--- a/src/cli/src/types.rs
+++ b/src/cli/src/types.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
@@ -19,9 +21,9 @@ pub enum LogLevel {
 }
 
 #[derive(Deserialize, Debug)]
-pub struct Config {
+pub struct YamlConfigFile {
     pub language: Language,
-    pub env_path: String,
-    pub code_path: String,
+    pub env_path: PathBuf,
+    pub code_path: PathBuf,
     pub log_level: LogLevel,
 }

--- a/src/cli/src/utils.rs
+++ b/src/cli/src/utils.rs
@@ -1,18 +1,18 @@
-use crate::types::Config;
+use crate::types::YamlConfigFile;
 use std::fs::File;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
-pub fn load_config(config_path: &PathBuf) -> io::Result<Config> {
+pub fn load_config(config_path: &PathBuf) -> io::Result<YamlConfigFile> {
     let mut file = File::open(config_path)?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
-    let config: Config = serde_yaml::from_str(&contents)
+    let config: YamlConfigFile = serde_yaml::from_str(&contents)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     Ok(config)
 }
 
-pub fn read_file(file_path: &str) -> io::Result<String> {
+pub fn read_file(file_path: &PathBuf) -> io::Result<String> {
     let mut file = File::open(file_path)?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;

--- a/src/cli/src/utils.rs
+++ b/src/cli/src/utils.rs
@@ -1,20 +1,24 @@
-use crate::types::YamlConfigFile;
+use shared_models::YamlClientConfigFile;
 use std::fs::File;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
-pub fn load_config(config_path: &PathBuf) -> io::Result<YamlConfigFile> {
-    let mut file = File::open(config_path)?;
-    let mut contents = String::new();
-    file.read_to_string(&mut contents)?;
-    let config: YamlConfigFile = serde_yaml::from_str(&contents)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-    Ok(config)
-}
+pub struct ConfigFileHandler {}
 
-pub fn read_file(file_path: &PathBuf) -> io::Result<String> {
-    let mut file = File::open(file_path)?;
-    let mut contents = String::new();
-    file.read_to_string(&mut contents)?;
-    Ok(contents)
+impl ConfigFileHandler {
+    pub fn load_config(config_path: &PathBuf) -> io::Result<YamlClientConfigFile> {
+        let mut file = File::open(config_path)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        let config: YamlClientConfigFile = serde_yaml::from_str(&contents)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(config)
+    }
+
+    pub fn read_file(file_path: &PathBuf) -> io::Result<String> {
+        let mut file = File::open(file_path)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        Ok(contents)
+    }
 }

--- a/src/shared-models/Cargo.toml
+++ b/src/shared-models/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cli"
+name = "shared_models"
 version = "0.1.0"
 edition = "2021"
 
@@ -7,11 +7,10 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.3", features = ["derive"] }
-toml = "0.8.12"
-tokio = { version = "1.36.0", features = ["full"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_yaml = "0.9.34"
-schemars = "0.8.16"
 serde_json = "1.0.115"
-reqwest = "0.12.3"
-shared_models = { path="../shared-models" }
+
+[lib]
+name = "shared_models"
+path = "src/lib.rs"

--- a/src/shared-models/src/lib.rs
+++ b/src/shared-models/src/lib.rs
@@ -6,24 +6,32 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, ValueEnum, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Language {
-    Rust,
-    Python,
-    Node,
+    RUST,
+    PYTHON,
+    NODE,
 }
 
 #[derive(Clone, Debug, ValueEnum, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LogLevel {
-    Debug,
-    Info,
-    Warn,
-    Error,
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR,
 }
 
 #[derive(Deserialize, Debug)]
-pub struct YamlConfigFile {
+pub struct YamlClientConfigFile {
     pub language: Language,
     pub env_path: PathBuf,
     pub code_path: PathBuf,
+    pub log_level: LogLevel,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CloudletDtoRequest {
+    pub language: Language,
+    pub env: String,
+    pub code: String,
     pub log_level: LogLevel,
 }


### PR DESCRIPTION
# Description 

This pull request aims to implement a gRPC client within the HTTP API in order to be able to call the lumper. A "proto" folder has been created to define interfaces for the client and server. A sub-project "shared-models" has been created to share types and serialization and deserialization macros between the CLI and API, particularly the main DTO used to execute a "lumper". A refactor has also been done with function and structure renaming.

## Test the CLI + API :

From API folder  :  `cargo run`
From CLI folder :  `cargo run -- run --config-path="<path>/cloudlet/src/cli/config/config.template.yaml"`