### PR TITLE
make(tools): run agent in init script

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -10,7 +10,7 @@ run:
   #!/bin/bash
   CARGO_PATH=$(which cargo)
   sudo -E capsh --keep=1 --user=$USER --inh=cap_net_admin --addamb=cap_net_admin -- -c \
-    'RUST_BACKTRACE=1 '$CARGO_PATH' run --bin vmm -- --memory 512 --cpus 1 \
+    'RUST_BACKTRACE=1 '$CARGO_PATH' run --bin vmm -- cli --memory 512 --cpus 1 \
     --kernel tools/kernel/linux-cloud-hypervisor/arch/x86/boot/compressed/vmlinux.bin \
     --network-host-ip 172.29.0.1 --network-host-netmask 255.255.0.0 \
     --initramfs=tools/rootfs/initramfs.img'
@@ -43,3 +43,14 @@ build-rootfs mode = "dev":
   pushd tools/rootfs
   ./mkrootfs.sh
   popd
+
+configure-slip pts_num:
+  #!/bin/bash
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run as root"
+    exit 1
+  fi
+  slattach -L /dev/pts/{{pts_num}} &
+  sleep 5
+  ip a add 172.30.0.10/16 dev sl0
+  ip l set sl0 up

--- a/src/agent/examples/config.toml
+++ b/src/agent/examples/config.toml
@@ -7,5 +7,5 @@ address = "localhost"
 port = 50051
 
 [build]
-source-code-path = "CHANGEME/cloudlet/src/agent/examples/main.rs"
+source-code-path = "CHANGE/cloudlet/src/agent/examples/main.rs"
 release = true

--- a/tools/rootfs/config.toml
+++ b/tools/rootfs/config.toml
@@ -1,3 +1,7 @@
 workload-name = "debug"
 language = "debug"
 action = "prepare-and-run"
+
+[server]
+address = "0.0.0.0"
+port = 50051

--- a/tools/rootfs/config.toml
+++ b/tools/rootfs/config.toml
@@ -1,0 +1,3 @@
+workload-name = "debug"
+language = "debug"
+action = "prepare-and-run"

--- a/tools/rootfs/mkrootfs.sh
+++ b/tools/rootfs/mkrootfs.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+set -e
+
 if [ ! -d alpine-minirootfs ]
 then
     curl -O https://dl-cdn.alpinelinux.org/alpine/v3.14/releases/x86_64/alpine-minirootfs-3.14.2-x86_64.tar.gz
@@ -8,13 +10,12 @@ then
     tar xf alpine-minirootfs-3.14.2-x86_64.tar.gz -C alpine-minirootfs
 fi
 
-cp ../../target/x86_64-unknown-linux-musl/release/agent alpine-minirootfs/agent
-
-mkdir -p alpine-minirootfs/etc/cloudlet/agent
-
-cp ../../src/agent/examples/config.toml etc/cloudlet/agent/config.toml
 
 pushd alpine-minirootfs
+mkdir -p etc/cloudlet/agent
+cp ../../../target/x86_64-unknown-linux-musl/release/agent agent
+cp ../config.toml etc/cloudlet/agent/config.toml
+
 cat > init <<EOF
 #! /bin/sh
 #

--- a/tools/rootfs/mkrootfs.sh
+++ b/tools/rootfs/mkrootfs.sh
@@ -8,6 +8,12 @@ then
     tar xf alpine-minirootfs-3.14.2-x86_64.tar.gz -C alpine-minirootfs
 fi
 
+cp ../../target/x86_64-unknown-linux-musl/release/agent alpine-minirootfs/agent
+
+mkdir -p alpine-minirootfs/etc/cloudlet/agent
+
+cp ../../src/agent/examples/config.toml etc/cloudlet/agent/config.toml
+
 pushd alpine-minirootfs
 cat > init <<EOF
 #! /bin/sh
@@ -28,8 +34,9 @@ done
 
 ifconfig sl0 172.30.0.11 netmask 255.255.0.0 up
 
-exec /sbin/getty -n -l /bin/sh 115200 /dev/console
-poweroff -f
+/agent
+
+reboot
 EOF
 
 chmod +x init


### PR DESCRIPTION
## What does this one do ?

- updates the Justfile to compile the agent with debug flag
- puts the agent binary into the vm
- change the init script to run it (kinda hacky, im open to better solutions)

## How to test it ?

Change the `language` key at `src/agent/examples/config.toml` to `debug` and run the following commands :

```
rm -rf tools/kernel/linux-cloud-hypervisor tools/rootfs/alpine-minirootfs*
just setup
just run
```

<img src="https://media1.tenor.com/m/hceJ4yCF2p4AAAAd/cat-hanging.gif" width="100" height="auto" alt="Cat Hanging GIF">