### PR TITLE
feat(fs-gen): stable version with agent insertion

### DIFF
--- a/src/fs-gen/Cargo.toml
+++ b/src/fs-gen/Cargo.toml
@@ -20,5 +20,5 @@ tar = "0.4.40"
 validator = { version = "0.17.0", features = ["derive"] }
 anyhow = "1.0.82"
 tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
+tracing-subscriber = {  version = "0.3.18", features = ["env-filter"] }
 thiserror = "1.0.59"

--- a/src/fs-gen/Cargo.toml
+++ b/src/fs-gen/Cargo.toml
@@ -21,3 +21,4 @@ validator = { version = "0.17.0", features = ["derive"] }
 anyhow = "1.0.82"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
+thiserror = "1.0.59"

--- a/src/fs-gen/Cargo.toml
+++ b/src/fs-gen/Cargo.toml
@@ -20,3 +20,4 @@ tar = "0.4.40"
 validator = { version = "0.17.0", features = ["derive"] }
 anyhow = "1.0.82"
 tracing = "0.1.40"
+tracing-subscriber = "0.3.18"

--- a/src/fs-gen/Cargo.toml
+++ b/src/fs-gen/Cargo.toml
@@ -19,3 +19,4 @@ signal-hook = "0.3.17"
 tar = "0.4.40"
 validator = { version = "0.17.0", features = ["derive"] }
 anyhow = "1.0.82"
+tracing = "0.1.40"

--- a/src/fs-gen/resources/initfile
+++ b/src/fs-gen/resources/initfile
@@ -1,11 +1,21 @@
-#!/bin/sh
+#! /bin/sh
 #
 # Cloudlet initramfs generation
 #
 mount -t devtmpfs dev /dev
 mount -t proc proc /proc
 mount -t sysfs sysfs /sys
+
 ip link set up dev lo
 
-exec /sbin/getty -n -l /bin/sh 115200 /dev/console
-poweroff -f
+slattach -L /dev/ttyS1&
+
+while ! ifconfig sl0 &> /dev/null; do
+    sleep 1
+done
+
+ifconfig sl0 172.30.0.11 netmask 255.255.0.0 up
+
+/agent
+
+reboot

--- a/src/fs-gen/resources/initfile
+++ b/src/fs-gen/resources/initfile
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Cloudlet initramfs generation
+#
+mount -t devtmpfs dev /dev
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+ip link set up dev lo
+
+exec /sbin/getty -n -l /bin/sh 115200 /dev/console
+poweroff -f

--- a/src/fs-gen/src/cli_args.rs
+++ b/src/fs-gen/src/cli_args.rs
@@ -31,6 +31,9 @@ pub struct CliArgs {
     #[arg(short='i', long="init", default_value=None)]
     pub initfile_path: Option<PathBuf>,
 
+    #[arg(long="arch", default_value="amd64")]
+    pub architecture: String,
+
     #[arg(short='d', long="debug", action=ArgAction::SetTrue)]
     pub debug: bool,
 }

--- a/src/fs-gen/src/cli_args.rs
+++ b/src/fs-gen/src/cli_args.rs
@@ -1,6 +1,6 @@
 use std::{env, path::PathBuf};
 
-use clap::{command, error::ErrorKind, CommandFactory, Parser, ArgAction};
+use clap::{command, error::ErrorKind, ArgAction, CommandFactory, Parser};
 use regex::Regex;
 
 use once_cell::sync::Lazy;
@@ -31,7 +31,7 @@ pub struct CliArgs {
     #[arg(short='i', long="init", default_value=None)]
     pub initfile_path: Option<PathBuf>,
 
-    #[arg(long="arch", default_value="amd64")]
+    #[arg(long = "arch", default_value = "amd64")]
     pub architecture: String,
 
     #[arg(short='d', long="debug", action=ArgAction::SetTrue)]

--- a/src/fs-gen/src/cli_args.rs
+++ b/src/fs-gen/src/cli_args.rs
@@ -66,13 +66,12 @@ impl CliArgs {
     }
 }
 
-/// Get the default output path for the cpio file.
+/// Get the default temporary directory for the current execution.
 fn get_default_temp_directory() -> PathBuf {
-    let mut path = env::current_dir().unwrap();
-    path.push(".cloudlet_temp/");
-    path
+    PathBuf::from("/tmp/cloudlet-fs-gen")
 }
 
+/// Get the default output file path for the generated initramfs.
 fn get_default_output_file() -> PathBuf {
     let mut path = env::current_dir().unwrap();
     path.push("initramfs.img");

--- a/src/fs-gen/src/cli_args.rs
+++ b/src/fs-gen/src/cli_args.rs
@@ -7,7 +7,7 @@ use once_cell::sync::Lazy;
 
 // So, for any of you who may be scared, this is the regex from the OCI Distribution Sepcification for the image name + the tag
 static RE_IMAGE_NAME: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(\/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*:[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}").unwrap()
+    Regex::new(r"[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*(?::[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127})?").unwrap()
 });
 
 /// Convert an OCI image into a CPIO file

--- a/src/fs-gen/src/cli_args.rs
+++ b/src/fs-gen/src/cli_args.rs
@@ -17,6 +17,9 @@ pub struct CliArgs {
     /// The name of the image to download
     pub image_name: String,
 
+    /// The host path to the guest agent binary
+    pub agent_host_path: PathBuf,
+
     /// The path to the output file
     #[arg(short='o', long="output", default_value=get_default_output_file().into_os_string())]
     pub output_file: PathBuf,
@@ -25,8 +28,8 @@ pub struct CliArgs {
     #[arg(short='t', long="tempdir", default_value=get_default_temp_directory().into_os_string())]
     pub temp_directory: PathBuf,
 
-    /// The host path to the guest agent binary
-    pub agent_host_path: PathBuf,
+    #[arg(short='i', long="init", default_value=None)]
+    pub initfile_path: Option<PathBuf>,
 }
 
 impl CliArgs {

--- a/src/fs-gen/src/cli_args.rs
+++ b/src/fs-gen/src/cli_args.rs
@@ -11,7 +11,7 @@ static RE_IMAGE_NAME: Lazy<Regex> = Lazy::new(|| {
 });
 
 /// Convert an OCI image into a CPIO file
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
 pub struct CliArgs {
     /// The name of the image to download

--- a/src/fs-gen/src/cli_args.rs
+++ b/src/fs-gen/src/cli_args.rs
@@ -1,6 +1,6 @@
 use std::{env, path::PathBuf};
 
-use clap::{command, error::ErrorKind, CommandFactory, Parser};
+use clap::{command, error::ErrorKind, CommandFactory, Parser, ArgAction};
 use regex::Regex;
 
 use once_cell::sync::Lazy;
@@ -30,6 +30,9 @@ pub struct CliArgs {
 
     #[arg(short='i', long="init", default_value=None)]
     pub initfile_path: Option<PathBuf>,
+
+    #[arg(short='d', long="debug", action=ArgAction::SetTrue)]
+    pub debug: bool,
 }
 
 impl CliArgs {

--- a/src/fs-gen/src/errors.rs
+++ b/src/fs-gen/src/errors.rs
@@ -1,0 +1,23 @@
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub(crate) enum ImageLoaderError {
+    /// There is no existing manifest for the given image.
+    #[error("Could not find Docker v2 or OCI manifest for `{0}:{1}`")]
+    ManifestNotFound(String, String),
+
+    /// Image doesn't support the requested architecture.
+    #[error("This image doesn't support {0} architecture")]
+    UnsupportedArchitecture(String),
+
+    /// The manifest doesn't contain any layers to unpack.
+    #[error("Could not find image layers in the manifest")]
+    LayersNotFound,
+
+    /// Encountered an error during the flow.
+    #[error("Image loading error: {}", .source)]
+    Error {
+        source: anyhow::Error
+    }
+}

--- a/src/fs-gen/src/image_builder.rs
+++ b/src/fs-gen/src/image_builder.rs
@@ -44,7 +44,7 @@ fn new_passthroughfs_layer(rootdir: &str) -> Result<BoxedLayer> {
 
 /// Ensure a destination folder is created
 fn ensure_folder_created(output_folder: &Path) -> Result<()> {
-    let result = fs::create_dir(output_folder);
+    let result = fs::create_dir_all(output_folder);
 
     // If the file already exists, we're fine
     if result.is_err() {

--- a/src/fs-gen/src/image_builder.rs
+++ b/src/fs-gen/src/image_builder.rs
@@ -13,7 +13,7 @@ use fuse_backend_rs::{
     passthrough::{self, PassthroughFs},
     transport::{FuseChannel, FuseSession},
 };
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 static FILE_EXISTS_ERROR: i32 = 17;
 
@@ -72,6 +72,8 @@ fn ensure_folder_created(output_folder: &Path) -> Result<()> {
 /// merge_layer(vec!["source/layer_1", "source/layer_2"], "/tmp/fused_layers", "/tmp")
 /// ```
 pub fn merge_layer(blob_paths: &[PathBuf], output_folder: &Path, tmp_folder: &Path) -> Result<()> {
+    info!("Starting to merge layers...");
+
     // Stack all lower layers
     let mut lower_layers = Vec::new();
     for lower in blob_paths {
@@ -134,6 +136,8 @@ pub fn merge_layer(blob_paths: &[PathBuf], output_folder: &Path, tmp_folder: &Pa
         .with_context(|| "Failed to unmount the fuse session".to_string())?;
 
     let _ = handle.join();
+    
+    info!("Finished merging layers!");
     Ok(())
 }
 

--- a/src/fs-gen/src/image_builder.rs
+++ b/src/fs-gen/src/image_builder.rs
@@ -136,7 +136,7 @@ pub fn merge_layer(blob_paths: &[PathBuf], output_folder: &Path, tmp_folder: &Pa
         .with_context(|| "Failed to unmount the fuse session".to_string())?;
 
     let _ = handle.join();
-    
+
     info!("Finished merging layers!");
     Ok(())
 }

--- a/src/fs-gen/src/initramfs_generator.rs
+++ b/src/fs-gen/src/initramfs_generator.rs
@@ -4,18 +4,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-const INIT_FILE: &[u8; 210] = b"#!/bin/sh
-#
-# Cloudlet initramfs generation
-#
-mount -t devtmpfs dev /dev
-mount -t proc proc /proc
-mount -t sysfs sysfs /sys
-ip link set up dev lo
-
-exec /sbin/getty -n -l /bin/sh 115200 /dev/console
-poweroff -f
-";
+const INIT_FILE: &str = include_str!("../resources/initfile");
 
 pub fn create_init_file(path: &Path, initfile: Option<PathBuf>) {
     let destination = path.join("init");
@@ -27,7 +16,7 @@ pub fn create_init_file(path: &Path, initfile: Option<PathBuf>) {
         // if there is none, write the default init file
         let mut file = File::create(destination).unwrap();
         file.set_permissions(Permissions::from_mode(0o755)).unwrap();
-        file.write_all(INIT_FILE)
+        file.write_all(INIT_FILE.as_bytes())
             .expect("Could not write init file");
     }
 }

--- a/src/fs-gen/src/initramfs_generator.rs
+++ b/src/fs-gen/src/initramfs_generator.rs
@@ -1,10 +1,10 @@
-use std::fs::{File, Permissions, copy as fscopy};
-use std::io::{Write, copy as iocopy};
+use anyhow::{Context, Result};
+use std::fs::{copy as fscopy, File, Permissions};
+use std::io::{copy as iocopy, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tracing::info;
-use anyhow::{Context, Result};
 
 const INIT_FILE: &str = include_str!("../resources/initfile");
 
@@ -39,8 +39,8 @@ pub fn insert_agent(destination: &Path, agent_path: PathBuf) -> Result<()> {
     file.set_permissions(Permissions::from_mode(0o755))
         .with_context(|| "Failed to set permissions for agent file".to_string())?;
 
-    let mut agent = File::open(agent_path)
-        .with_context(|| "Could not open host agent file".to_string())?;
+    let mut agent =
+        File::open(agent_path).with_context(|| "Could not open host agent file".to_string())?;
     iocopy(&mut agent, &mut file)
         .with_context(|| "Failed to copy agent contents from host to destination".to_string())?;
 
@@ -65,9 +65,9 @@ pub fn generate_initramfs(root_directory: &Path, output: &Path) -> Result<()> {
         .spawn()
         .with_context(|| "Failed to package initramfs into bundle".to_string())?;
 
-    command
-        .wait()
-        .with_context(|| "Encountered exception while waiting for bundling to finish".to_string())?;
+    command.wait().with_context(|| {
+        "Encountered exception while waiting for bundling to finish".to_string()
+    })?;
 
     info!("Initramfs generated!");
 

--- a/src/fs-gen/src/initramfs_generator.rs
+++ b/src/fs-gen/src/initramfs_generator.rs
@@ -4,44 +4,56 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tracing::info;
+use anyhow::{Context, Result};
 
 const INIT_FILE: &str = include_str!("../resources/initfile");
 
-pub fn create_init_file(path: &Path, initfile: Option<PathBuf>) {
+pub fn create_init_file(path: &Path, initfile: Option<PathBuf>) -> Result<()> {
     info!("Writing initfile...");
 
     let destination = path.join("init");
 
     if let Some(p) = initfile {
         // if there is a given initfile, we copy it into the folder
-        fscopy(p, destination).expect("Could not copy initfile");
+        fscopy(p, destination)
+            .with_context(|| "Failed to copy provided initfile to initramfs".to_string())?;
     } else {
         // if there is none, write the default init file
         let mut file = File::create(destination).unwrap();
         file.set_permissions(Permissions::from_mode(0o755)).unwrap();
+
         file.write_all(INIT_FILE.as_bytes())
-            .expect("Could not write init file");
+            .with_context(|| "Failed to write default initfile to initramfs".to_string())?;
     }
 
     info!("Initfile written!");
+
+    Ok(())
 }
 
-pub fn insert_agent(destination: &Path, agent_path: PathBuf) {
+pub fn insert_agent(destination: &Path, agent_path: PathBuf) -> Result<()> {
     info!("Inserting agent into fs...");
 
-    let mut file = File::create(destination.join("agent")).unwrap();
-    file.set_permissions(Permissions::from_mode(0o755)).unwrap();
+    let mut file = File::create(destination.join("agent"))
+        .with_context(|| "Could not open agent file inside initramfs".to_string())?;
+    file.set_permissions(Permissions::from_mode(0o755))
+        .with_context(|| "Failed to set permissions for agent file".to_string())?;
 
-    let mut agent = File::open(agent_path).unwrap();
-    iocopy(&mut agent, &mut file).expect("Could not copy agent");
+    let mut agent = File::open(agent_path)
+        .with_context(|| "Could not open host agent file".to_string())?;
+    iocopy(&mut agent, &mut file)
+        .with_context(|| "Failed to copy agent contents from host to destination".to_string())?;
 
     info!("Agent inserted!");
+
+    Ok(())
 }
 
-pub fn generate_initramfs(root_directory: &Path, output: &Path) {
-    let file = File::create(output).unwrap();
+pub fn generate_initramfs(root_directory: &Path, output: &Path) -> Result<()> {
+    let file = File::create(output)
+        .with_context(|| "Could not open output file to write initramfs".to_string())?;
     file.set_permissions(Permissions::from_mode(0o644))
-        .expect("Could not set permissions");
+        .with_context(|| "Failed to set permissions for output file".to_string())?;
 
     info!("Generating initramfs...");
 
@@ -51,10 +63,13 @@ pub fn generate_initramfs(root_directory: &Path, output: &Path) {
         .arg("-c")
         .arg("find . -print0 | cpio -0 --create --owner=root:root --format=newc | xz -9 --format=lzma")
         .spawn()
-        .expect("Failed to package initramfs");
+        .with_context(|| "Failed to package initramfs into bundle".to_string())?;
+
     command
         .wait()
-        .expect("Failed to wait for initramfs to finish");
+        .with_context(|| "Encountered exception while waiting for bundling to finish".to_string())?;
 
     info!("Initramfs generated!");
+
+    Ok(())
 }

--- a/src/fs-gen/src/initramfs_generator.rs
+++ b/src/fs-gen/src/initramfs_generator.rs
@@ -3,11 +3,13 @@ use std::io::{Write, copy as iocopy};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use fuse_backend_rs::api::filesystem::ZeroCopyReader;
+use tracing::info;
 
 const INIT_FILE: &str = include_str!("../resources/initfile");
 
 pub fn create_init_file(path: &Path, initfile: Option<PathBuf>) {
+    info!("Writing initfile...");
+
     let destination = path.join("init");
 
     if let Some(p) = initfile {
@@ -20,14 +22,20 @@ pub fn create_init_file(path: &Path, initfile: Option<PathBuf>) {
         file.write_all(INIT_FILE.as_bytes())
             .expect("Could not write init file");
     }
+
+    info!("Initfile written!");
 }
 
 pub fn insert_agent(destination: &Path, agent_path: PathBuf) {
+    info!("Inserting agent into fs...");
+
     let mut file = File::create(destination.join("agent")).unwrap();
     file.set_permissions(Permissions::from_mode(0o755)).unwrap();
 
     let mut agent = File::open(agent_path).unwrap();
     iocopy(&mut agent, &mut file).expect("Could not copy agent");
+
+    info!("Agent inserted!");
 }
 
 pub fn generate_initramfs(root_directory: &Path, output: &Path) {
@@ -35,7 +43,7 @@ pub fn generate_initramfs(root_directory: &Path, output: &Path) {
     file.set_permissions(Permissions::from_mode(0o644))
         .expect("Could not set permissions");
 
-    println!("Generating initramfs...");
+    info!("Generating initramfs...");
 
     let mut command = Command::new("sh")
         .current_dir(root_directory)
@@ -48,5 +56,5 @@ pub fn generate_initramfs(root_directory: &Path, output: &Path) {
         .wait()
         .expect("Failed to wait for initramfs to finish");
 
-    println!("Initramfs generated!");
+    info!("Initramfs generated!");
 }

--- a/src/fs-gen/src/loader/download.rs
+++ b/src/fs-gen/src/loader/download.rs
@@ -1,6 +1,6 @@
 use reqwest::blocking::Client;
 use std::fs::create_dir_all;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::{debug, info};
 use anyhow::{Context, Result};
 use serde_json::Value;
@@ -61,14 +61,14 @@ pub(crate) fn download_image_fs(
         Some(m) => {
             debug!("Downloading architecture-specific manifest");
 
-            let submanifest = download_manifest(
+            
+
+            download_manifest(
                 &client,
                 token,
                 image_name,
                 m["digest"].as_str().unwrap()
-            ).map_err(|e| ImageLoaderError::Error { source: e })?;
-
-            submanifest
+            ).map_err(|e| ImageLoaderError::Error { source: e })?
         }
     };
     
@@ -76,7 +76,7 @@ pub(crate) fn download_image_fs(
         None => Err(ImageLoaderError::LayersNotFound)?,
         Some(layers) => {
             create_dir_all(&output_file).with_context(|| "Could not create output directory for image downloading")?;
-            return download_layers(
+            download_layers(
                 layers,
                 &client,
                 token,
@@ -122,7 +122,7 @@ fn download_layers(
     client: &Client,
     token: &str,
     image_name: &str,
-    output_dir: &PathBuf,
+    output_dir: &Path,
 ) -> Result<Vec<PathBuf>> {
     info!("Downloading and unpacking layers...");
 

--- a/src/fs-gen/src/loader/download.rs
+++ b/src/fs-gen/src/loader/download.rs
@@ -1,7 +1,7 @@
 use reqwest::blocking::Client;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use anyhow::{Context, Result};
 use serde_json::Value;
 use crate::loader::errors::ImageLoaderError;
@@ -29,6 +29,10 @@ pub(crate) fn download_image_fs(
     if let Some(layers) = manifest["layers"].as_array() {
         // We have layers already, no need to look into sub-manifests.
         info!("Found layers in manifest");
+        warn!(
+            architecture,
+            "Manifest did not specify architecture, the initramfs may not work for the requested architecture"
+        );
         create_dir_all(&output_file).with_context(|| "Could not create output directory for image downloading")?;
         return download_layers(
             layers,

--- a/src/fs-gen/src/loader/errors.rs
+++ b/src/fs-gen/src/loader/errors.rs
@@ -17,9 +17,7 @@ pub(crate) enum ImageLoaderError {
 
     /// Encountered an error during the flow.
     #[error("Image loading error: {}", .source)]
-    Error {
-        source: anyhow::Error
-    }
+    Error { source: anyhow::Error },
 }
 
 impl From<anyhow::Error> for ImageLoaderError {

--- a/src/fs-gen/src/loader/errors.rs
+++ b/src/fs-gen/src/loader/errors.rs
@@ -1,4 +1,4 @@
-
+use anyhow::Error;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -19,5 +19,11 @@ pub(crate) enum ImageLoaderError {
     #[error("Image loading error: {}", .source)]
     Error {
         source: anyhow::Error
+    }
+}
+
+impl From<anyhow::Error> for ImageLoaderError {
+    fn from(value: Error) -> Self {
+        Self::Error { source: value }
     }
 }

--- a/src/fs-gen/src/loader/mod.rs
+++ b/src/fs-gen/src/loader/mod.rs
@@ -1,3 +1,3 @@
 pub(crate) mod download;
 pub(crate) mod errors;
-pub(self) mod utils;
+ mod utils;

--- a/src/fs-gen/src/loader/mod.rs
+++ b/src/fs-gen/src/loader/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod download;
+pub(crate) mod errors;
+pub(self) mod utils;

--- a/src/fs-gen/src/loader/mod.rs
+++ b/src/fs-gen/src/loader/mod.rs
@@ -1,3 +1,3 @@
 pub(crate) mod download;
 pub(crate) mod errors;
- mod utils;
+mod utils;

--- a/src/fs-gen/src/loader/utils.rs
+++ b/src/fs-gen/src/loader/utils.rs
@@ -1,0 +1,25 @@
+use flate2::read::GzDecoder;
+use reqwest::blocking::{Client, Response};
+use std::path::PathBuf;
+use tar::Archive;
+use anyhow::{Context, Result};
+
+/// Unpack the tarball to a given directory.
+pub(super) fn unpack_tarball(tar: GzDecoder<Response>, output_dir: &PathBuf) -> Result<()> {
+    Archive::new(tar).unpack(output_dir.clone())
+        .with_context(|| format!("Failed to unpack tarball to {}", output_dir.display()))?;
+    Ok(())
+}
+
+/// Get a token for anonymous authentication to Docker Hub.
+pub(super) fn get_docker_download_token(client: &Client, image_name: &str) -> Result<String> {
+    let token_json: serde_json::Value = client
+        .get(format!("https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/{image_name}:pull"))
+        .send().with_context(|| "Could not send request for anonymous authentication".to_string())?
+        .json().with_context(|| "Failed to parse JSON response for anonymous authentication".to_string())?;
+
+    match token_json["token"].as_str().with_context(|| "Failed to get token from anon auth response".to_string()) {
+        Ok(t) => Ok(t.to_owned()),
+        Err(e) => Err(e)
+    }
+}

--- a/src/fs-gen/src/loader/utils.rs
+++ b/src/fs-gen/src/loader/utils.rs
@@ -1,12 +1,12 @@
 use flate2::read::GzDecoder;
 use reqwest::blocking::{Client, Response};
-use std::path::PathBuf;
+use std::path::{Path};
 use tar::Archive;
 use anyhow::{Context, Result};
 
 /// Unpack the tarball to a given directory.
-pub(super) fn unpack_tarball(response: Response, output_dir: &PathBuf) -> Result<()> {
-    Archive::new(GzDecoder::new(response)).unpack(output_dir.clone())
+pub(super) fn unpack_tarball(response: Response, output_dir: &Path) -> Result<()> {
+    Archive::new(GzDecoder::new(response)).unpack(output_dir)
         .with_context(|| format!("Failed to unpack tarball to {}", output_dir.display()))?;
     Ok(())
 }

--- a/src/fs-gen/src/loader/utils.rs
+++ b/src/fs-gen/src/loader/utils.rs
@@ -1,12 +1,13 @@
+use anyhow::{Context, Result};
 use flate2::read::GzDecoder;
 use reqwest::blocking::{Client, Response};
-use std::path::{Path};
+use std::path::Path;
 use tar::Archive;
-use anyhow::{Context, Result};
 
 /// Unpack the tarball to a given directory.
 pub(super) fn unpack_tarball(response: Response, output_dir: &Path) -> Result<()> {
-    Archive::new(GzDecoder::new(response)).unpack(output_dir)
+    Archive::new(GzDecoder::new(response))
+        .unpack(output_dir)
         .with_context(|| format!("Failed to unpack tarball to {}", output_dir.display()))?;
     Ok(())
 }
@@ -18,8 +19,11 @@ pub(super) fn get_docker_download_token(client: &Client, image_name: &str) -> Re
         .send().with_context(|| "Could not send request for anonymous authentication".to_string())?
         .json().with_context(|| "Failed to parse JSON response for anonymous authentication".to_string())?;
 
-    match token_json["token"].as_str().with_context(|| "Failed to get token from anon auth response".to_string()) {
+    match token_json["token"]
+        .as_str()
+        .with_context(|| "Failed to get token from anon auth response".to_string())
+    {
         Ok(t) => Ok(t.to_owned()),
-        Err(e) => Err(e)
+        Err(e) => Err(e),
     }
 }

--- a/src/fs-gen/src/loader/utils.rs
+++ b/src/fs-gen/src/loader/utils.rs
@@ -5,8 +5,8 @@ use tar::Archive;
 use anyhow::{Context, Result};
 
 /// Unpack the tarball to a given directory.
-pub(super) fn unpack_tarball(tar: GzDecoder<Response>, output_dir: &PathBuf) -> Result<()> {
-    Archive::new(tar).unpack(output_dir.clone())
+pub(super) fn unpack_tarball(response: Response, output_dir: &PathBuf) -> Result<()> {
+    Archive::new(GzDecoder::new(response)).unpack(output_dir.clone())
         .with_context(|| format!("Failed to unpack tarball to {}", output_dir.display()))?;
     Ok(())
 }

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -1,7 +1,7 @@
 use std::{fs::remove_dir_all, path::Path};
 use std::path::PathBuf;
 use tracing::{debug, error, info, Level};
-use anyhow::{Result, Error, bail, Context};
+use anyhow::{Result, bail, Context};
 use crate::cli_args::CliArgs;
 
 use crate::initramfs_generator::{create_init_file, generate_initramfs, insert_agent};

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -1,8 +1,10 @@
 use std::{fs::remove_dir_all, path::Path};
-use tracing::{debug, error, info, Level};
+use tracing::{debug, error, info};
 use anyhow::{Result, bail, Context};
-use crate::cli_args::CliArgs;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::filter::EnvFilter;
 
+use crate::cli_args::CliArgs;
 use crate::initramfs_generator::{create_init_file, generate_initramfs, insert_agent};
 use crate::image_builder::merge_layer;
 use crate::loader::download::download_image_fs;
@@ -16,10 +18,9 @@ fn run(
     args: CliArgs,
 ) -> Result<()> {
     let layers_subdir = args.temp_directory.join("layers/");
-    let output_subdir = args.temp_directory.join("output/");
     let overlay_subdir = args.temp_directory.join("overlay/");
-
-    let path = Path::new(output_subdir.as_path());
+    let _binding = args.temp_directory.join("output/");
+    let output_subdir = _binding.as_path();
 
     // image downloading and unpacking
     let layers_paths = match download_image_fs(&args.image_name, &args.architecture, layers_subdir) {
@@ -29,12 +30,12 @@ fn run(
     debug!("Layers' paths: {:?}", layers_paths);
 
     // reconstructing image with overlayfs
-    merge_layer(&layers_paths, path, &overlay_subdir)?;
+    merge_layer(&layers_paths, output_subdir, &overlay_subdir)?;
 
     // building initramfs
-    create_init_file(path, args.initfile_path)?;
-    insert_agent(path, args.agent_host_path)?;
-    generate_initramfs(path, Path::new(args.output_file.as_path()))?;
+    create_init_file(output_subdir, args.initfile_path)?;
+    insert_agent(output_subdir, args.agent_host_path)?;
+    generate_initramfs(output_subdir, Path::new(args.output_file.as_path()))?;
 
     // cleanup of temporary directory
     remove_dir_all(args.temp_directory.clone())
@@ -47,10 +48,21 @@ fn main() -> Result<()> {
     let args = CliArgs::get_args();
 
     tracing_subscriber::fmt()
-        .with_max_level(if args.debug { Level::DEBUG } else { Level::INFO })
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(
+                    (if args.debug { LevelFilter::DEBUG } else { LevelFilter::INFO }).into()
+                )
+                .from_env()?
+                .add_directive("fuse_backend_rs=warn".parse()?)
+        )
         .init();
+    
+    // tracing_subscriber::fmt()
+    //     .with_max_level(if args.debug { Level::DEBUG } else { Level::INFO })
+    //     .init();
 
-    info!("Cloudlet initramfs generator v{}", env!("CARGO_PKG_VERSION"));
+    info!("Cloudlet initramfs generator: '{}' v{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
     info!("Generating for image '{}'", args.image_name);
 
     debug!(

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -22,7 +22,7 @@ fn run(
     let path = Path::new(output_subdir.as_path());
 
     // image downloading and unpacking
-    let layers_paths = match download_image_fs(&args.image_name, layers_subdir) {
+    let layers_paths = match download_image_fs(&args.image_name, &args.architecture, layers_subdir) {
         Err(e) => bail!(e),
         Ok(e) => e
     };
@@ -59,6 +59,7 @@ fn main() -> Result<()> {
         output_file = ?args.output_file,
         temp_dir = ?args.temp_directory,
         initfile_path = ?args.initfile_path,
+        architecture = args.architecture,
         debug = args.debug,
         "arguments:",
     );

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -1,6 +1,6 @@
 use std::{fs::remove_dir_all, path::Path};
 
-use crate::initramfs_generator::{create_init_file, generate_initramfs};
+use crate::initramfs_generator::{create_init_file, generate_initramfs, insert_agent};
 use image_builder::merge_layer;
 
 mod cli_args;
@@ -33,6 +33,8 @@ fn main() {
 
             merge_layer(&layers_paths, path, &overlay_subdir).expect("Merging layers failed");
             create_init_file(path, args.initfile_path);
+            insert_agent(path, args.agent_host_path);
+
             generate_initramfs(path, Path::new(args.output_file.as_path()));
         }
     }

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -1,12 +1,12 @@
+use anyhow::{bail, Context, Result};
 use std::{fs::remove_dir_all, path::Path};
-use tracing::{debug, error, info};
-use anyhow::{Result, bail, Context};
 use tracing::level_filters::LevelFilter;
+use tracing::{debug, error, info};
 use tracing_subscriber::filter::EnvFilter;
 
 use crate::cli_args::CliArgs;
-use crate::initramfs_generator::{create_init_file, generate_initramfs, insert_agent};
 use crate::image_builder::merge_layer;
+use crate::initramfs_generator::{create_init_file, generate_initramfs, insert_agent};
 use crate::loader::download::download_image_fs;
 
 mod cli_args;
@@ -14,18 +14,17 @@ mod image_builder;
 mod initramfs_generator;
 mod loader;
 
-fn run(
-    args: CliArgs,
-) -> Result<()> {
+fn run(args: CliArgs) -> Result<()> {
     let layers_subdir = args.temp_directory.join("layers/");
     let overlay_subdir = args.temp_directory.join("overlay/");
     let _binding = args.temp_directory.join("output/");
     let output_subdir = _binding.as_path();
 
     // image downloading and unpacking
-    let layers_paths = match download_image_fs(&args.image_name, &args.architecture, layers_subdir) {
+    let layers_paths = match download_image_fs(&args.image_name, &args.architecture, layers_subdir)
+    {
         Err(e) => bail!(e),
-        Ok(e) => e
+        Ok(e) => e,
     };
     debug!("Layers' paths: {:?}", layers_paths);
 
@@ -51,18 +50,27 @@ fn main() -> Result<()> {
         .with_env_filter(
             EnvFilter::builder()
                 .with_default_directive(
-                    (if args.debug { LevelFilter::DEBUG } else { LevelFilter::INFO }).into()
+                    (if args.debug {
+                        LevelFilter::DEBUG
+                    } else {
+                        LevelFilter::INFO
+                    })
+                    .into(),
                 )
                 .from_env()?
-                .add_directive("fuse_backend_rs=warn".parse()?)
+                .add_directive("fuse_backend_rs=warn".parse()?),
         )
         .init();
-    
+
     // tracing_subscriber::fmt()
     //     .with_max_level(if args.debug { Level::DEBUG } else { Level::INFO })
     //     .init();
 
-    info!("Cloudlet initramfs generator: '{}' v{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    info!(
+        "Cloudlet initramfs generator: '{}' v{}",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION")
+    );
     info!("Generating for image '{}'", args.image_name);
 
     debug!(

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -44,11 +44,10 @@ fn main() {
             let path = Path::new(output_subdir.as_path());
 
             merge_layer(&layers_paths, path, &overlay_subdir).expect("Merging layers failed");
+            create_init_file(path, args.initfile_path)?;
+            insert_agent(path, args.agent_host_path)?;
 
-            create_init_file(path, args.initfile_path);
-            insert_agent(path, args.agent_host_path);
-
-            generate_initramfs(path, Path::new(args.output_file.as_path()));
+            generate_initramfs(path, Path::new(args.output_file.as_path()))?;
         }
     }
 

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -30,7 +30,8 @@ fn main() {
             // FIXME: use a subdir of the temp directory instead
             let path = Path::new(overlay_subdir.as_path());
 
-            merge_layer(&layers_paths, path).expect("Merging layers failed");
+            merge_layer(&layers_paths, path, &args.temp_directory.clone())
+                .expect("Merging layers failed");
             create_init_file(path);
             generate_initramfs(path, Path::new(args.output_file.as_path()));
         }

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -1,6 +1,5 @@
 use std::{fs::remove_dir_all, path::Path};
 use tracing::{debug, error, info, Level};
-use tracing_subscriber;
 
 use crate::initramfs_generator::{create_init_file, generate_initramfs, insert_agent};
 use image_builder::merge_layer;

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
             let path = Path::new(output_subdir.as_path());
 
             merge_layer(&layers_paths, path, &overlay_subdir).expect("Merging layers failed");
-            create_init_file(path);
+            create_init_file(path, args.initfile_path);
             generate_initramfs(path, Path::new(args.output_file.as_path()));
         }
     }

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -1,5 +1,4 @@
 use std::{fs::remove_dir_all, path::Path};
-use std::path::PathBuf;
 use tracing::{debug, error, info, Level};
 use anyhow::{Result, bail, Context};
 use crate::cli_args::CliArgs;
@@ -15,10 +14,11 @@ mod loader;
 
 fn run(
     args: CliArgs,
-    layers_subdir: PathBuf,
-    output_subdir: PathBuf,
-    overlay_subdir: PathBuf,
 ) -> Result<()> {
+    let layers_subdir = args.temp_directory.join("layers/");
+    let output_subdir = args.temp_directory.join("output/");
+    let overlay_subdir = args.temp_directory.join("overlay/");
+
     let path = Path::new(output_subdir.as_path());
 
     // image downloading and unpacking
@@ -64,12 +64,7 @@ fn main() -> Result<()> {
         "arguments:",
     );
 
-    if let Err(e) = run(
-        args.clone(),
-        args.clone().temp_directory.clone().join("layers/"),
-        args.clone().temp_directory.clone().join("output/"),
-        args.clone().temp_directory.clone().join("overlay/")
-    ) {
+    if let Err(e) = run(args) {
         error!(error = ?e, "encountered error while running");
         Err(e)
     } else {

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -1,4 +1,6 @@
 use std::{fs::remove_dir_all, path::Path};
+use tracing::{debug, error, info, Level};
+use tracing_subscriber;
 
 use crate::initramfs_generator::{create_init_file, generate_initramfs, insert_agent};
 use image_builder::merge_layer;
@@ -10,28 +12,40 @@ mod initramfs_generator;
 
 fn main() {
     let args = cli_args::CliArgs::get_args();
-    println!("Hello, world!, {:?}", args);
+
+    tracing_subscriber::fmt()
+        .with_max_level(if args.debug { Level::DEBUG } else { Level::INFO })
+        .init();
+
+    info!("Cloudlet initramfs generator v{}", env!("CARGO_PKG_VERSION"));
+    info!("Generating for image '{}'", args.image_name);
+
+    debug!(
+        image_name = args.image_name,
+        agent_host_path = ?args.agent_host_path,
+        output_file = ?args.output_file,
+        temp_dir = ?args.temp_directory,
+        initfile_path = ?args.initfile_path,
+        debug = args.debug,
+        "arguments:",
+    );
 
     let layers_subdir = args.temp_directory.clone().join("layers/");
     let output_subdir = args.temp_directory.clone().join("output/");
     let overlay_subdir = args.temp_directory.clone().join("overlay/");
 
-    // TODO: better organise layers and OverlayFS build in the temp directory
     match image_loader::download_image_fs(&args.image_name, layers_subdir) {
         Err(e) => {
-            eprintln!("Error: {}", e);
+            error!(%e, "Received error while downloading image");
             return;
         }
         Ok(layers_paths) => {
-            println!("Image downloaded successfully! Layers' paths:");
-            for path in &layers_paths {
-                println!(" - {}", path.display());
-            }
+            debug!("Layers' paths: {:?}", layers_paths);
 
-            // FIXME: use a subdir of the temp directory instead
             let path = Path::new(output_subdir.as_path());
 
             merge_layer(&layers_paths, path, &overlay_subdir).expect("Merging layers failed");
+
             create_init_file(path, args.initfile_path);
             insert_agent(path, args.agent_host_path);
 

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -13,6 +13,7 @@ fn main() {
     println!("Hello, world!, {:?}", args);
 
     let layers_subdir = args.temp_directory.clone().join("layers/");
+    let output_subdir = args.temp_directory.clone().join("output/");
     let overlay_subdir = args.temp_directory.clone().join("overlay/");
 
     // TODO: better organise layers and OverlayFS build in the temp directory
@@ -28,10 +29,9 @@ fn main() {
             }
 
             // FIXME: use a subdir of the temp directory instead
-            let path = Path::new(overlay_subdir.as_path());
+            let path = Path::new(output_subdir.as_path());
 
-            merge_layer(&layers_paths, path, &args.temp_directory.clone())
-                .expect("Merging layers failed");
+            merge_layer(&layers_paths, path, &overlay_subdir).expect("Merging layers failed");
             create_init_file(path);
             generate_initramfs(path, Path::new(args.output_file.as_path()));
         }


### PR DESCRIPTION
This PR adds several functionalities:
- `--arch` argument to specify which architecture we want to download, if the manifest contains several
- `--initfile` argument, which takes a path in the host to copy the initfile from. If not given, the default initfile contained within the crate will be applied
- the agent is now placed under `/agent` in the rootFS, and executed by the default initfile
- logging has been implemented using `tracing` and `tracing_subscriber`
- crate now has better handling using `anyhow` for error reporting, and `thiserror` for error generation