### PR TITLE
refactor: clean code

### DIFF
--- a/src/agent/src/agents/rust.rs
+++ b/src/agent/src/agents/rust.rs
@@ -52,15 +52,16 @@ impl RustAgent {
     }
 }
 
-// TODO should change with a TryFrom
-impl From<workload::config::Config> for RustAgent {
-    fn from(workload_config: workload::config::Config) -> Self {
-        let rust_config: RustAgentConfig = toml::from_str(&workload_config.config_string).unwrap();
+impl TryFrom<workload::config::Config> for RustAgent {
+    type Error = Box<dyn std::error::Error>;
 
-        Self {
+    fn try_from(workload_config: workload::config::Config) -> Result<Self, Self::Error> {
+        let rust_config: RustAgentConfig = toml::from_str(&workload_config.config_string)?;
+
+        Ok(Self {
             workload_config,
             rust_config,
-        }
+        })
     }
 }
 

--- a/src/agent/src/workload/runner.rs
+++ b/src/agent/src/workload/runner.rs
@@ -19,7 +19,7 @@ pub struct Runner {
 impl Runner {
     pub fn new(config: Config) -> Self {
         let agent: Box<dyn Agent + Sync + Send> = match config.language {
-            Language::Rust => Box::new(rust::RustAgent::try_from(config.clone()).unwrap()),
+            Language::Rust => Box::new(rust::RustAgent::try_from(config.clone()).expect("Failed to convert Config to RustAgent")),
             #[cfg(feature = "debug-agent")]
             Language::Debug => Box::new(debug::DebugAgent::from(config.clone())),
         };

--- a/src/agent/src/workload/runner.rs
+++ b/src/agent/src/workload/runner.rs
@@ -19,7 +19,7 @@ pub struct Runner {
 impl Runner {
     pub fn new(config: Config) -> Self {
         let agent: Box<dyn Agent + Sync + Send> = match config.language {
-            Language::Rust => Box::new(rust::RustAgent::from(config.clone())),
+            Language::Rust => Box::new(rust::RustAgent::try_from(config.clone()).unwrap()),
             #[cfg(feature = "debug-agent")]
             Language::Debug => Box::new(debug::DebugAgent::from(config.clone())),
         };


### PR DESCRIPTION
# Pull Request: Refactor/clean code

## Description:
The goal of this PR is to introduce the implementation of the TryFrom trait for the RustAgent struct. Moreover, the point is also to clear the code, cleaning unwrap and other bad practices.

## Changes:
Todo : 
- [x] Changed From to TryFrom (Rust agent)
- [ ] Handle some unwrap()
- [ ] ...

## Testing:
As before