### PR TITLE
Feat: add initramfs implementation for vmm

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -29,6 +29,11 @@ build-agent args = "":
     -w /volume \
     -t clux/muslrust \
     cargo build --release --bin agent {{args}}
+  
+build-musl-agent args = "":
+  #!/bin/bash
+  rustup target add x86_64-unknown-linux-musl
+  cargo build --release --bin agent --target=x86_64-unknown-linux-musl
 
 build-rootfs mode = "dev":
   #!/bin/bash

--- a/proto/vmm.proto
+++ b/proto/vmm.proto
@@ -3,9 +3,9 @@ syntax = "proto3";
 package vmmorchestrator;
 
 enum Language {
-  PYTHON = 0;
-  NODE = 1;
-  RUST = 2;
+  RUST = 0;
+  PYTHON = 1;
+  NODE = 2;
 }
 
 enum LogLevel {

--- a/src/api/src/service.rs
+++ b/src/api/src/service.rs
@@ -22,9 +22,9 @@ pub async fn run(req_body: web::Json<CloudletDtoRequest>) -> impl Responder {
         workload_name: req.workload_name,
         code: req.code,
         language: match req.language {
-            Language::PYTHON => 0,
-            Language::NODE => 1,
-            Language::RUST => 2,
+            Language::RUST => 0,
+            Language::PYTHON => 1,
+            Language::NODE => 2,
         },
         log_level: req.log_level as i32,
     };

--- a/src/fs-gen/resources/initfile
+++ b/src/fs-gen/resources/initfile
@@ -8,7 +8,11 @@ mount -t sysfs sysfs /sys
 
 ip link set up dev lo
 
-ifconfig eth0 172.29.0.2 netmask 255.255.0.0 up
+export CARGO_HOME='/usr/local/cargo'
+export RUSTUP_HOME='/usr/local/rustup'
+export RUST_VERSION='1.77.2'
+
+export PATH=$CARGO_HOME/bin:$PATH
 
 /agent
 

--- a/src/fs-gen/resources/initfile
+++ b/src/fs-gen/resources/initfile
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# Cloudlet initramfs generation
+# /init executable file in the initramfs
 #
 mount -t devtmpfs dev /dev
 mount -t proc proc /proc
@@ -8,13 +8,7 @@ mount -t sysfs sysfs /sys
 
 ip link set up dev lo
 
-slattach -L /dev/ttyS1&
-
-while ! ifconfig sl0 &> /dev/null; do
-    sleep 1
-done
-
-ifconfig sl0 172.30.0.11 netmask 255.255.0.0 up
+ifconfig eth0 172.29.0.2 netmask 255.255.0.0 up
 
 /agent
 

--- a/src/vmm/src/args.rs
+++ b/src/vmm/src/args.rs
@@ -59,7 +59,7 @@ pub struct CliArguments {
 
 impl CliArguments {
     /// Get the log level filter.
-    pub fn _convert_log_to_tracing(&self) -> level_filters::LevelFilter {
+    pub fn convert_log_to_tracing(&self) -> level_filters::LevelFilter {
         match self.verbose.log_level_filter() {
             log::LevelFilter::Off => level_filters::LevelFilter::OFF,
             log::LevelFilter::Error => level_filters::LevelFilter::ERROR,

--- a/src/vmm/src/args.rs
+++ b/src/vmm/src/args.rs
@@ -59,7 +59,7 @@ pub struct CliArguments {
 
 impl CliArguments {
     /// Get the log level filter.
-    pub fn convert_log_to_tracing(&self) -> level_filters::LevelFilter {
+    pub fn _convert_log_to_tracing(&self) -> level_filters::LevelFilter {
         match self.verbose.log_level_filter() {
             log::LevelFilter::Off => level_filters::LevelFilter::OFF,
             log::LevelFilter::Error => level_filters::LevelFilter::ERROR,

--- a/src/vmm/src/core/vmm.rs
+++ b/src/vmm/src/core/vmm.rs
@@ -29,7 +29,7 @@ use super::irq_allocator::IrqAllocator;
 use super::slip_pty::SlipPty;
 
 #[cfg(target_arch = "x86_64")]
-pub(crate) const MMIO_GAP_END: u64 = 1 << 32;
+pub(crate) const MMIO_GAP_END: u64 = 1 << 34;
 /// Size of the MMIO gap.
 #[cfg(target_arch = "x86_64")]
 pub(crate) const MMIO_GAP_SIZE: u64 = 768 << 20;

--- a/src/vmm/src/grpc/server.rs
+++ b/src/vmm/src/grpc/server.rs
@@ -57,7 +57,7 @@ impl VmmServiceTrait for VmmService {
         kernel_entire_path.push("/tools/kernel/linux-cloud-hypervisor/arch/x86/boot/compressed/vmlinux.bin");
 
         // Check if the kernel is on the system, else build it
-        let kernel_exists = Path::new(&kernel_entire_path).try_exists().expect(&format!("Could not access folder {:?}", &kernel_entire_path));
+        let kernel_exists = Path::new(&kernel_entire_path).try_exists().unwrap_or_else(|_| panic!("Could not access folder {:?}", &kernel_entire_path));
         if !kernel_exists
         {
             info!("Kernel not found, building kernel");
@@ -99,14 +99,14 @@ impl VmmServiceTrait for VmmService {
         };
 
 
-        let rootfs_exists = Path::new(&initramfs_entire_file_path).try_exists().expect(&format!("Could not access file {:?}", &initramfs_entire_file_path));
+        let rootfs_exists = Path::new(&initramfs_entire_file_path).try_exists().unwrap_or_else(|_| panic!("Could not access folder {:?}", &initramfs_entire_file_path));
         if !rootfs_exists {
             // check if agent binary exists
             let agent_file_name = curr_dir.as_mut_os_string();
             agent_file_name.push("/target/x86_64-unknown-linux-musl/release/agent");
 
             // if agent hasn't been build, build it
-            let agent_exists = Path::new(&agent_file_name).try_exists().expect(&format!("Could not access file {:?}", &agent_file_name));
+            let agent_exists = Path::new(&agent_file_name).try_exists().unwrap_or_else(|_| panic!("Could not access folder {:?}", &agent_file_name));
             if !agent_exists {
                 //build agent
                 info!("Building agent binary");
@@ -146,7 +146,7 @@ impl VmmServiceTrait for VmmService {
         let mut vmm = VMM::new(HOST_IP, HOST_NETMASK, GUEST_IP).map_err(VmmErrors::VmmNew)?;
 
         // Configure the VMM parameters might need to be calculated rather than hardcoded
-        vmm.configure(2, 4000, kernel_path, &Some(initramfs_path))
+        vmm.configure(1, 4000, kernel_path, &Some(initramfs_path))
             .map_err(VmmErrors::VmmConfigure)?;
 
         // Run the VMM in a separate task

--- a/src/vmm/src/grpc/server.rs
+++ b/src/vmm/src/grpc/server.rs
@@ -1,7 +1,7 @@
-use crate::grpc::client::agent::ExecuteRequest;
 use self::vmmorchestrator::{
-    vmm_service_server::VmmService as VmmServiceTrait, Language, RunVmmRequest
+    vmm_service_server::VmmService as VmmServiceTrait, Language, RunVmmRequest,
 };
+use crate::grpc::client::agent::ExecuteRequest;
 use crate::VmmErrors;
 use crate::{core::vmm::VMM, grpc::client::WorkloadClient};
 use std::time::Duration;
@@ -89,7 +89,8 @@ impl VmmServiceTrait for VmmService {
 
         // get request with the language
         let vmm_request = request.into_inner();
-        let language: Language = Language::from_i32(vmm_request.language).expect("Unknown language");
+        let language: Language =
+            Language::from_i32(vmm_request.language).expect("Unknown language");
 
         let image = match language {
             Language::Rust => {

--- a/src/vmm/src/grpc/server.rs
+++ b/src/vmm/src/grpc/server.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use std::{
     convert::From,
     env::current_dir,
+    env::current_dir,
     net::Ipv4Addr,
     path::{Path, PathBuf},
     process::{Command, Stdio},

--- a/src/vmm/src/grpc/server.rs
+++ b/src/vmm/src/grpc/server.rs
@@ -88,8 +88,8 @@ impl VmmServiceTrait for VmmService {
         initramfs_entire_file_path.push("/tools/rootfs/");
 
         // get request with the language
-        let req: RunVmmRequest = request.into_inner();
-        let language: Language = Language::from_i32(req.language).expect("Unknown language");
+        let vmm_request = request.into_inner();
+        let language: Language = Language::from_i32(vmm_request.language).expect("Unknown language");
 
         let image = match language {
             Language::Rust => {
@@ -181,13 +181,12 @@ impl VmmServiceTrait for VmmService {
         .unwrap();
 
         // Send the grpc request to start the agent
-        let vmm_request = request.into_inner();
         let agent_request = ExecuteRequest {
             workload_name: vmm_request.workload_name,
             language: match vmm_request.language {
-                0 => "python".to_string(),
-                1 => "node".to_string(),
-                2 => "rust".to_string(),
+                0 => "rust".to_string(),
+                1 => "python".to_string(),
+                2 => "node".to_string(),
                 _ => unreachable!("Invalid language"),
             },
             action: 2, // Prepare and run

--- a/src/vmm/src/grpc/server.rs
+++ b/src/vmm/src/grpc/server.rs
@@ -63,10 +63,9 @@ impl VmmServiceTrait for VmmService {
             .push("/tools/kernel/linux-cloud-hypervisor/arch/x86/boot/compressed/vmlinux.bin");
 
         // Check if the kernel is on the system, else build it
-        let kernel_exists = Path::new(&kernel_entire_path).try_exists().expect(&format!(
-            "Could not access folder {:?}",
-            &kernel_entire_path
-        ));
+        let kernel_exists = Path::new(&kernel_entire_path)
+            .try_exists()
+            .unwrap_or_else(|_| panic!("Could not access folder {:?}", &kernel_entire_path));
 
         if !kernel_exists {
             info!("Kernel not found, building kernel");
@@ -109,10 +108,9 @@ impl VmmServiceTrait for VmmService {
 
         let rootfs_exists = Path::new(&initramfs_entire_file_path)
             .try_exists()
-            .expect(&format!(
-                "Could not access folder {:?}",
-                &initramfs_entire_file_path
-            ));
+            .unwrap_or_else(|_| {
+                panic!("Could not access folder {:?}", &initramfs_entire_file_path)
+            });
         if !rootfs_exists {
             // check if agent binary exists
             let agent_file_name = curr_dir.as_mut_os_string();
@@ -121,7 +119,7 @@ impl VmmServiceTrait for VmmService {
             // if agent hasn't been build, build it
             let agent_exists = Path::new(&agent_file_name)
                 .try_exists()
-                .expect(&format!("Could not access folder {:?}", &agent_file_name));
+                .unwrap_or_else(|_| panic!("Could not access folder {:?}", &agent_file_name));
             if !agent_exists {
                 //build agent
                 info!("Building agent binary");

--- a/src/vmm/src/main.rs
+++ b/src/vmm/src/main.rs
@@ -1,7 +1,8 @@
 use crate::args::{CliArgs, Commands};
 use clap::Parser;
 use tonic::transport::Server;
-use tracing::info;
+use tracing::{info, level_filters::LevelFilter};
+use tracing_subscriber::EnvFilter;
 use vmm::{
     core::vmm::VMM,
     grpc::server::{vmmorchestrator, VmmService},
@@ -13,6 +14,17 @@ mod args;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse the configuration and configure logger verbosity
     let args = CliArgs::parse();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(
+                    LevelFilter::INFO
+                    .into(),
+                )
+                .from_env()?
+        )
+        .init();
 
     info!(
         app_name = env!("CARGO_PKG_NAME"),

--- a/src/vmm/src/main.rs
+++ b/src/vmm/src/main.rs
@@ -14,8 +14,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse the configuration and configure logger verbosity
     let args = CliArgs::parse();
 
-    tracing_subscriber::fmt().init();
-
     info!(
         app_name = env!("CARGO_PKG_NAME"),
         app_version = env!("CARGO_PKG_VERSION"),
@@ -28,6 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // check if the args is grpc or command
     match args.command {
         Commands::Grpc => {
+            tracing_subscriber::fmt().init();
             Server::builder()
                 .add_service(vmmorchestrator::vmm_service_server::VmmServiceServer::new(
                     vmm_service,
@@ -36,6 +35,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .await?;
         }
         Commands::Cli(cli_args) => {
+            tracing_subscriber::fmt()
+                .with_max_level(cli_args.convert_log_to_tracing())
+                .init();
+
             // Create a new VMM
             let mut vmm = VMM::new(
                 cli_args.iface_host_addr,

--- a/src/vmm/src/main.rs
+++ b/src/vmm/src/main.rs
@@ -2,7 +2,6 @@ use crate::args::{CliArgs, Commands};
 use clap::Parser;
 use tonic::transport::Server;
 use tracing::{info, level_filters::LevelFilter};
-use tracing_subscriber::EnvFilter;
 use vmm::{
     core::vmm::VMM,
     grpc::server::{vmmorchestrator, VmmService},
@@ -15,16 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse the configuration and configure logger verbosity
     let args = CliArgs::parse();
 
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::builder()
-                .with_default_directive(
-                    LevelFilter::INFO
-                    .into(),
-                )
-                .from_env()?
-        )
-        .init();
+    tracing_subscriber::fmt().init();
 
     info!(
         app_name = env!("CARGO_PKG_NAME"),

--- a/src/vmm/src/main.rs
+++ b/src/vmm/src/main.rs
@@ -1,7 +1,7 @@
 use crate::args::{CliArgs, Commands};
 use clap::Parser;
 use tonic::transport::Server;
-use tracing::{info, level_filters::LevelFilter};
+use tracing::info;
 use vmm::{
     core::vmm::VMM,
     grpc::server::{vmmorchestrator, VmmService},

--- a/src/vmm/src/main.rs
+++ b/src/vmm/src/main.rs
@@ -36,9 +36,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .await?;
         }
         Commands::Cli(cli_args) => {
-            tracing_subscriber::fmt()
-                .with_max_level(cli_args.convert_log_to_tracing())
-                .init();
             // Create a new VMM
             let mut vmm = VMM::new(
                 cli_args.iface_host_addr,

--- a/tools/kernel/linux-config-x86_64
+++ b/tools/kernel/linux-config-x86_64
@@ -1475,6 +1475,8 @@ CONFIG_VIRTIO_NET=y
 # CONFIG_PPP is not set
 CONFIG_SLIP=y
 CONFIG_SLIP_COMPRESSED=y
+CONFIG_SLIP_SMART=n
+CONFIG_SLIP_MODE_SLIP6=n
 
 #
 # Host-side USB support is needed for USB Network Adapter support

--- a/tools/kernel/mkkernel.sh
+++ b/tools/kernel/mkkernel.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/bash
 
 LINUX_REPO=linux-cloud-hypervisor
+cd ./tools/kernel/
 
 if [ ! -d $LINUX_REPO ]
 then
     git clone --depth 1 "https://github.com/cloud-hypervisor/linux.git" -b "ch-6.2" $LINUX_REPO
 fi
 
-pushd $LINUX_REPO
+cd $LINUX_REPO
 cp ../linux-config-x86_64 .config
 KCFLAGS="-Wa,-mx86-used-note=no" make bzImage -j `nproc`
-popd

--- a/tools/rootfs/mkrootfs.sh
+++ b/tools/rootfs/mkrootfs.sh
@@ -11,7 +11,7 @@ ulimit -Sn 8192
 
 if [ -d fs-gen ]
 then
-    cargo run --bin fs-gen -- $1 ./fs-gen/test -o $2
+    cargo run --bin fs-gen -- $1 $2 -o $3
 else
     echo "Module fs-gen not found"
 fi

--- a/tools/rootfs/mkrootfs.sh
+++ b/tools/rootfs/mkrootfs.sh
@@ -8,7 +8,7 @@ fi
 
 if [ -d fs-gen ]
 then
-    cargo run --bin fs-gen -- alpine:latest ./fs-gen/test -o ../tools/rootfs/initramfs.img
+    cargo run --bin fs-gen -- $1 ./fs-gen/test -o ../tools/rootfs/initramfs.img
 else
     echo "Module fs-gen not found"
 fi

--- a/tools/rootfs/mkrootfs.sh
+++ b/tools/rootfs/mkrootfs.sh
@@ -6,6 +6,9 @@ then
     cd src
 fi
 
+# augment the open file limit
+ulimit -Sn 8192
+
 if [ -d fs-gen ]
 then
     cargo run --bin fs-gen -- $1 ./fs-gen/test -o ../tools/rootfs/initramfs.img

--- a/tools/rootfs/mkrootfs.sh
+++ b/tools/rootfs/mkrootfs.sh
@@ -11,7 +11,7 @@ ulimit -Sn 8192
 
 if [ -d fs-gen ]
 then
-    cargo run --bin fs-gen -- $1 ./fs-gen/test -o ../tools/rootfs/initramfs.img
+    cargo run --bin fs-gen -- $1 ./fs-gen/test -o $2
 else
     echo "Module fs-gen not found"
 fi

--- a/tools/rootfs/mkrootfs.sh
+++ b/tools/rootfs/mkrootfs.sh
@@ -1,43 +1,14 @@
 #!/usr/bin/bash
-
-set -e
-
-if [ ! -d alpine-minirootfs ]
+# test if its already in src folder => fs-gen available
+# launch from src folder at the same level as tools
+if [ -d src ]
 then
-    curl -O https://dl-cdn.alpinelinux.org/alpine/v3.14/releases/x86_64/alpine-minirootfs-3.14.2-x86_64.tar.gz
-
-    mkdir alpine-minirootfs
-    tar xf alpine-minirootfs-3.14.2-x86_64.tar.gz -C alpine-minirootfs
+    cd src
 fi
 
-
-pushd alpine-minirootfs
-mkdir -p etc/cloudlet/agent
-cp ../../../target/x86_64-unknown-linux-musl/release/agent agent
-cp ../config.toml etc/cloudlet/agent/config.toml
-
-cat > init <<EOF
-#! /bin/sh
-#
-# /init executable file in the initramfs
-#
-mount -t devtmpfs dev /dev
-mount -t proc proc /proc
-mount -t sysfs sysfs /sys
-
-ip link set up dev lo
-
-ifconfig eth0 172.29.0.2 netmask 255.255.0.0 up
-
-/agent
-
-reboot
-EOF
-
-chmod +x init
-
-find . -print0 |
-    cpio --null --create --verbose --owner root:root --format=newc |
-    xz -9 --format=lzma  > ../initramfs.img
-
-popd
+if [ -d fs-gen ]
+then
+    cargo run --bin fs-gen -- alpine:latest ./fs-gen/test -o ../tools/rootfs/initramfs.img
+else
+    echo "Module fs-gen not found"
+fi


### PR DESCRIPTION
# What does this PR do

This PR impelments the initramfs generation
- 1 fs for each language based on alpine
- each fs will have the agent on them

*This PR doesn't implement the code transmission between the client and the vm. This will happen at a later date*

# How to test this ?

You need to open 3 command lines simultaneously and launch these three commands:

Api:
```
cargo run --bin api
```

Vmm
```
cargo build
sudo -E capsh --keep=1 --user=$USER --inh=cap_net_admin --addamb=cap_net_admin -- -c  'RUST_BACKTRACE=1 '$CARGO_PATH' run --bin vmm -- grpc'
```

Client:
```
cargo run --bin cli run --config-path <path_to_cloudlet>/src/cli/config/config.yaml
```

You should see a vm booted on the vmm terminal that launches the agent - as of today it will produce an error since the agent needs an argument to work