### PR TITLE
Agent: sigterm children

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -16,6 +16,8 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-stream = "0.1.15"
 toml = "0.8.12"
 tonic = "0.11"
+nix = { version = "0.28.0", features = ["signal"] }
+once_cell = "1.19.0"
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -8,7 +8,10 @@ name = "agent"
 path = "src/lib.rs"
 
 [dependencies]
+async-trait = "0.1.80"
 clap = { version = "4.5.4", features = ["derive", "env"] }
+nix = { version = "0.28.0", features = ["signal"] }
+once_cell = "1.19.0"
 prost = "0.12.4"
 rand = "0.8.5"
 serde = { version = "1.0.197", features = ["derive"] }
@@ -16,8 +19,6 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-stream = "0.1.15"
 toml = "0.8.12"
 tonic = "0.11"
-nix = { version = "0.28.0", features = ["signal"] }
-once_cell = "1.19.0"
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/src/agent/src/agents/debug.rs
+++ b/src/agent/src/agents/debug.rs
@@ -1,10 +1,9 @@
 use super::AgentOutput;
 use crate::agents::Agent;
 use crate::{workload, AgentResult};
+use async_trait::async_trait;
 use std::collections::HashSet;
 use std::fs::create_dir_all;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
 use tokio::sync::Mutex;
@@ -19,53 +18,44 @@ impl From<workload::config::Config> for DebugAgent {
     }
 }
 
+#[async_trait]
 impl Agent for DebugAgent {
-    fn prepare(
-        &self,
-        _: &Arc<Mutex<HashSet<u32>>>,
-    ) -> Pin<Box<dyn Future<Output = AgentResult<AgentOutput>> + Send + '_>> {
-        Box::pin(async {
-            let dir = format!("/tmp/{}", self.workload_config.workload_name);
+    async fn prepare(&self, _: Arc<Mutex<HashSet<u32>>>) -> AgentResult<AgentOutput> {
+        let dir = format!("/tmp/{}", self.workload_config.workload_name);
 
-            println!("Function directory: {}", dir);
+        println!("Function directory: {}", dir);
 
-            create_dir_all(&dir).expect("Unable to create directory");
+        create_dir_all(&dir).expect("Unable to create directory");
 
-            std::fs::write(
-                format!("{}/debug.txt", &dir),
-                format!(
-                    "Debug agent for {} - written at {:?}",
-                    self.workload_config.workload_name,
-                    SystemTime::now(),
-                ),
-            )
-            .expect("Unable to write debug.txt file");
+        std::fs::write(
+            format!("{}/debug.txt", &dir),
+            format!(
+                "Debug agent for {} - written at {:?}",
+                self.workload_config.workload_name,
+                SystemTime::now(),
+            ),
+        )
+        .expect("Unable to write debug.txt file");
 
-            Ok(AgentOutput {
-                exit_code: 0,
-                stdout: "Build successfully!".into(),
-                stderr: String::default(),
-            })
+        Ok(AgentOutput {
+            exit_code: 0,
+            stdout: "Build successfully!".into(),
+            stderr: String::default(),
         })
     }
 
-    fn run(
-        &self,
-        _: &Arc<Mutex<HashSet<u32>>>,
-    ) -> Pin<Box<dyn Future<Output = AgentResult<AgentOutput>> + Send + '_>> {
-        Box::pin(async {
-            let dir = format!("/tmp/{}", self.workload_config.workload_name);
+    async fn run(&self, _: Arc<Mutex<HashSet<u32>>>) -> AgentResult<AgentOutput> {
+        let dir = format!("/tmp/{}", self.workload_config.workload_name);
 
-            let content = std::fs::read_to_string(format!("{}/debug.txt", &dir))
-                .expect("Unable to read debug.txt file");
+        let content = std::fs::read_to_string(format!("{}/debug.txt", &dir))
+            .expect("Unable to read debug.txt file");
 
-            std::fs::remove_dir_all(dir).expect("Unable to remove directory");
+        std::fs::remove_dir_all(dir).expect("Unable to remove directory");
 
-            Ok(AgentOutput {
-                exit_code: 0,
-                stdout: content,
-                stderr: String::default(),
-            })
+        Ok(AgentOutput {
+            exit_code: 0,
+            stdout: content,
+            stderr: String::default(),
         })
     }
 }

--- a/src/agent/src/agents/debug.rs
+++ b/src/agent/src/agents/debug.rs
@@ -1,8 +1,13 @@
 use super::AgentOutput;
 use crate::agents::Agent;
 use crate::{workload, AgentResult};
+use std::collections::HashSet;
 use std::fs::create_dir_all;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
 use std::time::SystemTime;
+use tokio::sync::Mutex;
 
 pub struct DebugAgent {
     workload_config: workload::config::Config,
@@ -15,42 +20,52 @@ impl From<workload::config::Config> for DebugAgent {
 }
 
 impl Agent for DebugAgent {
-    fn prepare(&self) -> AgentResult<AgentOutput> {
-        let dir = format!("/tmp/{}", self.workload_config.workload_name);
+    fn prepare(
+        &self,
+        _: &Arc<Mutex<HashSet<u32>>>,
+    ) -> Pin<Box<dyn Future<Output = AgentResult<AgentOutput>> + Send + '_>> {
+        Box::pin(async {
+            let dir = format!("/tmp/{}", self.workload_config.workload_name);
 
-        println!("Function directory: {}", dir);
+            println!("Function directory: {}", dir);
 
-        create_dir_all(&dir).expect("Unable to create directory");
+            create_dir_all(&dir).expect("Unable to create directory");
 
-        std::fs::write(
-            format!("{}/debug.txt", &dir),
-            format!(
-                "Debug agent for {} - written at {:?}",
-                self.workload_config.workload_name,
-                SystemTime::now(),
-            ),
-        )
-        .expect("Unable to write debug.txt file");
+            std::fs::write(
+                format!("{}/debug.txt", &dir),
+                format!(
+                    "Debug agent for {} - written at {:?}",
+                    self.workload_config.workload_name,
+                    SystemTime::now(),
+                ),
+            )
+            .expect("Unable to write debug.txt file");
 
-        Ok(AgentOutput {
-            exit_code: 0,
-            stdout: "Build successfully!".into(),
-            stderr: String::default(),
+            Ok(AgentOutput {
+                exit_code: 0,
+                stdout: "Build successfully!".into(),
+                stderr: String::default(),
+            })
         })
     }
 
-    fn run(&self) -> AgentResult<AgentOutput> {
-        let dir = format!("/tmp/{}", self.workload_config.workload_name);
+    fn run(
+        &self,
+        _: &Arc<Mutex<HashSet<u32>>>,
+    ) -> Pin<Box<dyn Future<Output = AgentResult<AgentOutput>> + Send + '_>> {
+        Box::pin(async {
+            let dir = format!("/tmp/{}", self.workload_config.workload_name);
 
-        let content = std::fs::read_to_string(format!("{}/debug.txt", &dir))
-            .expect("Unable to read debug.txt file");
+            let content = std::fs::read_to_string(format!("{}/debug.txt", &dir))
+                .expect("Unable to read debug.txt file");
 
-        std::fs::remove_dir_all(dir).expect("Unable to remove directory");
+            std::fs::remove_dir_all(dir).expect("Unable to remove directory");
 
-        Ok(AgentOutput {
-            exit_code: 0,
-            stdout: content,
-            stderr: String::default(),
+            Ok(AgentOutput {
+                exit_code: 0,
+                stdout: content,
+                stderr: String::default(),
+            })
         })
     }
 }

--- a/src/agent/src/agents/mod.rs
+++ b/src/agent/src/agents/mod.rs
@@ -1,5 +1,10 @@
 use crate::{AgentError, AgentResult};
 use serde::Deserialize;
+use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 #[cfg(feature = "debug-agent")]
 pub mod debug;
@@ -13,8 +18,14 @@ pub struct AgentOutput {
 }
 
 pub trait Agent {
-    fn prepare(&self) -> AgentResult<AgentOutput>;
-    fn run(&self) -> AgentResult<AgentOutput>;
+    fn prepare<'a>(
+        &'a self,
+        child_processes: &'a Arc<Mutex<HashSet<u32>>>,
+    ) -> Pin<Box<dyn Future<Output = AgentResult<AgentOutput>> + Send + '_>>;
+    fn run<'a>(
+        &'a self,
+        child_processes: &'a Arc<Mutex<HashSet<u32>>>,
+    ) -> Pin<Box<dyn Future<Output = AgentResult<AgentOutput>> + Send + '_>>;
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/agent/src/agents/mod.rs
+++ b/src/agent/src/agents/mod.rs
@@ -1,8 +1,7 @@
 use crate::{AgentError, AgentResult};
+use async_trait::async_trait;
 use serde::Deserialize;
 use std::collections::HashSet;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -17,15 +16,10 @@ pub struct AgentOutput {
     pub stderr: String,
 }
 
+#[async_trait]
 pub trait Agent {
-    fn prepare<'a>(
-        &'a self,
-        child_processes: &'a Arc<Mutex<HashSet<u32>>>,
-    ) -> Pin<Box<dyn Future<Output = AgentResult<AgentOutput>> + Send + '_>>;
-    fn run<'a>(
-        &'a self,
-        child_processes: &'a Arc<Mutex<HashSet<u32>>>,
-    ) -> Pin<Box<dyn Future<Output = AgentResult<AgentOutput>> + Send + '_>>;
+    async fn prepare(&self, child_processes: Arc<Mutex<HashSet<u32>>>) -> AgentResult<AgentOutput>;
+    async fn run(&self, child_processes: Arc<Mutex<HashSet<u32>>>) -> AgentResult<AgentOutput>;
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/agent/src/agents/rust.rs
+++ b/src/agent/src/agents/rust.rs
@@ -82,8 +82,6 @@ impl Agent for RustAgent {
         child_processes: &'a Arc<Mutex<HashSet<u32>>>,
     ) -> Pin<Box<dyn Future<Output = AgentResult<AgentOutput>> + Send + '_>> {
         Box::pin(async {
-            let code = std::fs::read_to_string(&self.rust_config.build.source_code_path).unwrap();
-
             let function_dir = format!(
                 "/tmp/{}",
                 Alphanumeric.sample_string(&mut rand::thread_rng(), 16)
@@ -93,60 +91,61 @@ impl Agent for RustAgent {
 
             create_dir_all(format!("{}/src", &function_dir)).expect("Unable to create directory");
 
-        std::fs::write(
-            format!("{}/src/main.rs", &function_dir),
-            &self.workload_config.code,
-        )
-        .expect("Unable to write main.rs file");
+            std::fs::write(
+                format!("{}/src/main.rs", &function_dir),
+                &self.workload_config.code,
+            )
+            .expect("Unable to write main.rs file");
 
-        let cargo_toml = format!(
-            r#"
+            let cargo_toml = format!(
+                r#"
             [package]
             name = "{}"
             version = "0.1.0"
             edition = "2018"
         "#,
-            self.workload_config.workload_name
-        );
+                self.workload_config.workload_name
+            );
 
-        std::fs::write(format!("{}/Cargo.toml", &function_dir), cargo_toml)
-            .expect("Unable to write Cargo.toml file");
+            std::fs::write(format!("{}/Cargo.toml", &function_dir), cargo_toml)
+                .expect("Unable to write Cargo.toml file");
 
             let result = self.build(&function_dir, child_processes).await?;
 
-        if result.exit_code != 0 {
-            println!("Build failed: {:?}", result);
-            return Err(AgentError::BuildFailed(AgentOutput {
+            if result.exit_code != 0 {
+                println!("Build failed: {:?}", result);
+                return Err(AgentError::BuildFailed(AgentOutput {
+                    exit_code: result.exit_code,
+                    stdout: result.stdout,
+                    stderr: result.stderr,
+                }));
+            }
+
+            // Copy the binary to /tmp, we could imagine a more complex scenario where we would put this in an artifact repository (like S3)
+            let binary_path = match self.rust_config.build.release {
+                true => format!(
+                    "{}/target/release/{}",
+                    &function_dir, self.workload_config.workload_name
+                ),
+                false => format!(
+                    "{}/target/debug/{}",
+                    &function_dir, self.workload_config.workload_name
+                ),
+            };
+
+            std::fs::copy(
+                binary_path,
+                format!("/tmp/{}", self.workload_config.workload_name),
+            )
+            .expect("Unable to copy binary");
+
+            std::fs::remove_dir_all(&function_dir).expect("Unable to remove directory");
+
+            Ok(AgentOutput {
                 exit_code: result.exit_code,
-                stdout: result.stdout,
-                stderr: result.stderr,
-            }));
-        }
-
-        // Copy the binary to /tmp, we could imagine a more complex scenario where we would put this in an artifact repository (like S3)
-        let binary_path = match self.rust_config.build.release {
-            true => format!(
-                "{}/target/release/{}",
-                &function_dir, self.workload_config.workload_name
-            ),
-            false => format!(
-                "{}/target/debug/{}",
-                &function_dir, self.workload_config.workload_name
-            ),
-        };
-
-        std::fs::copy(
-            binary_path,
-            format!("/tmp/{}", self.workload_config.workload_name),
-        )
-        .expect("Unable to copy binary");
-
-        std::fs::remove_dir_all(&function_dir).expect("Unable to remove directory");
-
-        Ok(AgentOutput {
-            exit_code: result.exit_code,
-            stdout: "Build successful".to_string(),
-            stderr: "".to_string(),
+                stdout: "Build successful".to_string(),
+                stderr: "".to_string(),
+            })
         })
     }
 
@@ -159,17 +158,22 @@ impl Agent for RustAgent {
                 .spawn()
                 .expect("Failed to run function");
 
-        let agent_output = AgentOutput {
-            exit_code: output.status.code().unwrap(),
-            stdout: std::str::from_utf8(&output.stdout).unwrap().to_string(),
-            stderr: std::str::from_utf8(&output.stderr).unwrap().to_string(),
-        };
+            child_processes.lock().await.insert(child.id());
 
-        if !output.status.success() {
-            println!("Run failed: {:?}", agent_output);
-            return Err(AgentError::BuildFailed(agent_output));
-        }
+            let output = child.wait_with_output().expect("Failed to wait on child");
 
-        Ok(agent_output)
+            let agent_output = AgentOutput {
+                exit_code: output.status.code().unwrap(),
+                stdout: std::str::from_utf8(&output.stdout).unwrap().to_string(),
+                stderr: std::str::from_utf8(&output.stderr).unwrap().to_string(),
+            };
+
+            if !output.status.success() {
+                println!("Run failed: {:?}", agent_output);
+                return Err(AgentError::BuildFailed(agent_output));
+            }
+
+            Ok(agent_output)
+        })
     }
 }

--- a/src/agent/src/agents/rust.rs
+++ b/src/agent/src/agents/rust.rs
@@ -3,10 +3,10 @@ use crate::{workload, AgentError, AgentResult};
 use rand::distributions::{Alphanumeric, DistString};
 use serde::Deserialize;
 use std::collections::HashSet;
+use std::fs::create_dir_all;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::{fs::create_dir_all};
 use tokio::process::Command;
 use tokio::sync::Mutex;
 
@@ -42,7 +42,10 @@ impl RustAgent {
 
             child_processes.lock().await.insert(child.id().unwrap());
 
-            let output = child.wait_with_output().await.expect("Failed to wait on child");
+            let output = child
+                .wait_with_output()
+                .await
+                .expect("Failed to wait on child");
 
             Ok(AgentOutput {
                 exit_code: output.status.code().unwrap(),
@@ -55,8 +58,11 @@ impl RustAgent {
                 .current_dir(function_dir)
                 .spawn()
                 .expect("Failed to build function");
-            
-            let output = child.wait_with_output().await.expect("Failed to wait on child");
+
+            let output = child
+                .wait_with_output()
+                .await
+                .expect("Failed to wait on child");
 
             Ok(AgentOutput {
                 exit_code: output.status.code().unwrap(),
@@ -163,7 +169,10 @@ impl Agent for RustAgent {
 
             child_processes.lock().await.insert(child.id().unwrap());
 
-            let output = child.wait_with_output().await.expect("Failed to wait on child");
+            let output = child
+                .wait_with_output()
+                .await
+                .expect("Failed to wait on child");
 
             let agent_output = AgentOutput {
                 exit_code: output.status.code().unwrap(),

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -2,15 +2,8 @@ use agent::{
     agent::workload_runner_server::WorkloadRunnerServer, workload::service::WorkloadRunnerService,
 };
 use clap::Parser;
-use once_cell::sync::Lazy;
-use std::collections::HashSet;
-use std::sync::Arc;
-use std::{net::ToSocketAddrs, path::PathBuf};
-use tokio::sync::Mutex;
+use std::net::ToSocketAddrs;
 use tonic::transport::Server;
-
-static CHILD_PROCESSES: Lazy<Arc<Mutex<HashSet<u32>>>> =
-    Lazy::new(|| Arc::new(Mutex::new(HashSet::new())));
 
 #[derive(Debug, Parser)]
 struct Args {

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -2,8 +2,15 @@ use agent::{
     agent::workload_runner_server::WorkloadRunnerServer, workload::service::WorkloadRunnerService,
 };
 use clap::Parser;
-use std::net::ToSocketAddrs;
+use once_cell::sync::Lazy;
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::{net::ToSocketAddrs, path::PathBuf};
+use tokio::sync::Mutex;
 use tonic::transport::Server;
+
+static CHILD_PROCESSES: Lazy<Arc<Mutex<HashSet<u32>>>> =
+    Lazy::new(|| Arc::new(Mutex::new(HashSet::new())));
 
 #[derive(Debug, Parser)]
 struct Args {

--- a/src/agent/src/workload/runner.rs
+++ b/src/agent/src/workload/runner.rs
@@ -36,9 +36,12 @@ impl Runner {
         }
     }
 
-    pub fn new_from_execute_request(execute_request: ExecuteRequest) -> Result<Self, AgentError> {
+    pub fn new_from_execute_request(
+        execute_request: ExecuteRequest,
+        child_processes: Arc<Mutex<HashSet<u32>>>,
+    ) -> Result<Self, AgentError> {
         let config = Config::new_from_execute_request(execute_request)?;
-        Ok(Self::new(config))
+        Ok(Self::new(config, child_processes))
     }
 
     pub async fn run(&self) -> AgentResult<AgentOutput> {

--- a/src/agent/src/workload/service.rs
+++ b/src/agent/src/workload/service.rs
@@ -57,7 +57,10 @@ impl WorkloadRunner for WorkloadRunnerService {
                 nix::sys::signal::Signal::SIGTERM,
             ) {
                 Ok(_) => println!("Sent SIGTERM to child process {}", child_id),
-                Err(e) => println!("Failed to send SIGTERM to child process {}: {}", child_id, e),
+                Err(e) => println!(
+                    "Failed to send SIGTERM to child process {}: {}",
+                    child_id, e
+                ),
             }
         }
 

--- a/src/agent/src/workload/service.rs
+++ b/src/agent/src/workload/service.rs
@@ -52,11 +52,13 @@ impl WorkloadRunner for WorkloadRunnerService {
         let child_processes = CHILD_PROCESSES.lock().await;
 
         for &child_id in child_processes.iter() {
-            nix::sys::signal::kill(
+            match nix::sys::signal::kill(
                 nix::unistd::Pid::from_raw(child_id as i32),
                 nix::sys::signal::Signal::SIGTERM,
-            )
-            .unwrap();
+            ) {
+                Ok(_) => println!("Sent SIGTERM to child process {}", child_id),
+                Err(e) => println!("Failed to send SIGTERM to child process {}: {}", child_id, e),
+            }
         }
 
         process::exit(0);


### PR DESCRIPTION
This PR now handle better the `signal` received by the vmm to gracefully shut down children processes by sending them a sigterm and waiting for them before exiting the process.

More type of signal could be interpreted and sent easily to the children processes.