### PR TITLE
feat: stop vm when agent finished executing

### DIFF
--- a/src/cli/src/services.rs
+++ b/src/cli/src/services.rs
@@ -12,6 +12,7 @@ struct TomlConfig {
     workload_name: String,
     language: Language,
     action: String,
+    #[serde(default)]
     server: ServerConfig,
     build: BuildConfig,
 }

--- a/src/shared-models/src/lib.rs
+++ b/src/shared-models/src/lib.rs
@@ -44,7 +44,7 @@ pub struct CloudletShutdownResponse {
     pub success: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct ServerConfig {
     pub address: String,
     pub port: u16,

--- a/src/shared-models/src/lib.rs
+++ b/src/shared-models/src/lib.rs
@@ -44,10 +44,20 @@ pub struct CloudletShutdownResponse {
     pub success: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ServerConfig {
     pub address: String,
     pub port: u16,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        ServerConfig {
+            address: String::from("localhost"),
+            port: 50051
+        }
+
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/vmm/src/grpc/server.rs
+++ b/src/vmm/src/grpc/server.rs
@@ -184,7 +184,7 @@ impl VmmServiceTrait for VmmService {
     }
 
     async fn run(&self, request: Request<RunVmmRequest>) -> Result<Self::RunStream> {
-        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
 
         const HOST_IP: Ipv4Addr = Ipv4Addr::new(172, 29, 0, 1);
         const HOST_NETMASK: Ipv4Addr = Ipv4Addr::new(255, 255, 0, 0);
@@ -259,6 +259,12 @@ impl VmmServiceTrait for VmmService {
                         let _ = tx.send(Ok(vmm_response)).await;
                     }
                 });
+
+                rx.close();
+
+                // once the execution is stopped, stop the agent
+                let signal_request = crate::grpc::client::agent::SignalRequest {};
+                let _ = client.signal(signal_request).await;
             }
             Err(e) => {
                 error!("ERROR {:?}", e);

--- a/src/vmm/src/grpc/server.rs
+++ b/src/vmm/src/grpc/server.rs
@@ -262,8 +262,6 @@ impl VmmServiceTrait for VmmService {
                     let signal_request = ShutdownVmRequest {};
                     let _ = client.shutdown(signal_request).await;
                 });
-
-
             }
             Err(e) => {
                 error!("ERROR {:?}", e);


### PR DESCRIPTION
# What does this PR do ?

It sends a request to the agent to stop after they have finished executing the code

# How to test ?

You need to open 3 command lines simultaneously and launch these three commands:

Api:
```
cargo run --bin api
```

Vmm
```
cargo build
sudo -E capsh --keep=1 --user=$USER --inh=cap_net_admin --addamb=cap_net_admin -- -c  'RUST_BACKTRACE=1 '$CARGO_PATH' run --bin vmm -- grpc'
```

Client:
```
cargo run --bin cli run --config-path <path_to_cloudlet>/src/cli/config/config.yaml
```

You should see a vm booted on the vmm terminal that launches the agent and stops as soon as the code is finished executing