### PR TITLE
fix(virtio-net): waiting infinetely for bridge to be created

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@
 Install the dependencies. On Debian/Ubuntu:
 
 ```bash
-apt install build-essential cmake pkg-config libssl-dev flex bison libelf-dev
+apt install build-essential cmake pkg-config libssl-dev flex bison libelf-dev iptables
 ```
 
-Then, configure the Rust toolchain and install [Just](https://github.com/casey/just):
+Then, configure the Rust toolchain and install [Just](https://github.com/casey/just) (only for dev environment):
 
 ```bash
 rustup target add x86_64-unknown-linux-musl
-cargo install just
+cargo install just # optional
 ```
 
 Finally, install [the protobuf compiler](https://github.com/protocolbuffers/protobuf?tab=readme-ov-file#protobuf-compiler-installation).

--- a/src/vmm/src/core/devices/virtio/net/bridge.rs
+++ b/src/vmm/src/core/devices/virtio/net/bridge.rs
@@ -84,7 +84,7 @@ impl Bridge {
         let bridge_index = self.get_index_by_name(&self.name).await?;
         let prefix_len = xx_netmask_width(netmask.octets());
 
-        let does_addr_already_exists = self
+        let addr_get_request = self
             .handle
             .address()
             .get()
@@ -94,7 +94,7 @@ impl Bridge {
             .execute()
             .try_next()
             .await;
-        if does_addr_already_exists.is_ok() {
+        if let Ok(Some(_)) = addr_get_request {
             info!("address {:?} already exists for bridge", addr);
 
             return Ok(());

--- a/src/vmm/src/core/devices/virtio/net/mod.rs
+++ b/src/vmm/src/core/devices/virtio/net/mod.rs
@@ -13,12 +13,14 @@ const NET_DEVICE_ID: u32 = 1;
 const VIRTIO_NET_HDR_SIZE: usize = 12;
 const RXQ_INDEX: u16 = 0;
 const TXQ_INDEX: u16 = 1;
+const BRIDGE_NAME: &str = "br0";
 
 #[derive(Debug)]
 pub enum Error {
     Virtio(virtio::Error),
     TunTap(open_tap::Error),
     Tap(tap::Error),
+    Bridge(bridge::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/vmm/src/core/vmm.rs
+++ b/src/vmm/src/core/vmm.rs
@@ -69,7 +69,7 @@ pub struct VMM {
 
 impl VMM {
     /// Create a new VMM.
-    pub async fn new(
+    pub fn new(
         iface_host_addr: Ipv4Addr,
         netmask: Ipv4Addr,
         iface_guest_addr: Ipv4Addr,

--- a/src/vmm/src/grpc/server.rs
+++ b/src/vmm/src/grpc/server.rs
@@ -212,9 +212,7 @@ impl VmmServiceTrait for VmmService {
 
         let initramfs_path = self.get_initramfs(&language, curr_dir.as_os_str())?;
 
-        let mut vmm = VMM::new(HOST_IP, HOST_NETMASK, GUEST_IP)
-            .await
-            .map_err(VmmErrors::VmmNew)?;
+        let mut vmm = VMM::new(HOST_IP, HOST_NETMASK, GUEST_IP).map_err(VmmErrors::VmmNew)?;
 
         // Configure the VMM parameters might need to be calculated rather than hardcoded
         vmm.configure(1, 4000, kernel_path, &Some(initramfs_path))

--- a/src/vmm/src/grpc/server.rs
+++ b/src/vmm/src/grpc/server.rs
@@ -31,6 +31,9 @@ pub mod agent {
 // Implement the From trait for VmmErrors into Status
 impl From<VmmErrors> for Status {
     fn from(error: VmmErrors) -> Self {
+        // log the gRPC error before sending it
+        error!("VMM error: {:?}", error);
+
         // You can create a custom Status variant based on the error
         match error {
             VmmErrors::VmmNew(_) => Status::internal("Error creating VMM"),

--- a/src/vmm/src/grpc/server.rs
+++ b/src/vmm/src/grpc/server.rs
@@ -209,10 +209,13 @@ impl VmmServiceTrait for VmmService {
 
         let initramfs_path = self.get_initramfs(&language, curr_dir.as_os_str())?;
 
-        let mut vmm = VMM::new(HOST_IP, HOST_NETMASK, GUEST_IP).map_err(VmmErrors::VmmNew)?;
+        let mut vmm = VMM::new(HOST_IP, HOST_NETMASK, GUEST_IP)
+            .await
+            .map_err(VmmErrors::VmmNew)?;
 
         // Configure the VMM parameters might need to be calculated rather than hardcoded
         vmm.configure(1, 4000, kernel_path, &Some(initramfs_path))
+            .await
             .map_err(VmmErrors::VmmConfigure)?;
 
         // Run the VMM in a separate task

--- a/src/vmm/src/main.rs
+++ b/src/vmm/src/main.rs
@@ -45,6 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 cli_args.netmask,
                 cli_args.iface_guest_addr,
             )
+            .await
             .map_err(VmmErrors::VmmNew)
             .unwrap();
 
@@ -54,6 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 cli_args.kernel,
                 &cli_args.initramfs,
             )
+            .await
             .map_err(VmmErrors::VmmConfigure)
             .unwrap();
 

--- a/src/vmm/src/main.rs
+++ b/src/vmm/src/main.rs
@@ -45,7 +45,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 cli_args.netmask,
                 cli_args.iface_guest_addr,
             )
-            .await
             .map_err(VmmErrors::VmmNew)
             .unwrap();
 


### PR DESCRIPTION
# What does this PR do?

As I've seen with @sylvain-pierrot and @thomas-mauran, the problem comes from [`vmm::core::devices::virtio::net::bridge#L26`](https://github.com/virt-do/cloudlet/blob/main/src/vmm/src/core/devices/virtio/net/bridge.rs#L26) where the `futures::executor::block_on` (so everywhere there is this in this module). The future seems to never be polled by the executor, so from `tokio` or `futures`.

To solve the problem, I removed all of these (`block_on`), updated the function signatures with `async` in [bridge.rs](https://github.com/virt-do/cloudlet/blob/main/src/vmm/src/core/devices/virtio/net/bridge.rs) and propagated it up to the VMM.  
(I also refactored the code in `bridge.rs` to be a bit more readable.)

## Expected behavior

### Before:

The VMM orchestrator wait infinitely at the Net configuration step:
![image](https://github.com/virt-do/cloudlet/assets/22498591/6d412123-b701-4dfb-9097-c51e8ec0edf8)

### After:

Now it works correctly, and I've added a bit of logging to see the step in the network part:
![image](https://github.com/virt-do/cloudlet/assets/22498591/50ec10a8-d516-4189-b19b-e7b32ac93806)