### PR TITLE
feat: continuous logs (prepare and run)

### DIFF
--- a/proto/agent.proto
+++ b/proto/agent.proto
@@ -26,10 +26,10 @@ message ExecuteResponse {
     DEBUG = 5;
   }
 
-  string stdout = 1;
-  string stderr = 2;
-  Stage stage = 3;
-  int32 exit_code = 4;
+  Stage stage = 1;
+  optional string stdout = 2;
+  optional string stderr = 3;
+  optional int32 exit_code = 4;
 }
 
 message SignalRequest {

--- a/proto/vmm.proto
+++ b/proto/vmm.proto
@@ -26,9 +26,10 @@ message ExecuteResponse {
     DEBUG = 5;
   }
 
-  string stdout = 1;
-  string stderr = 2;
-  int32 exit_code = 3;
+  Stage stage = 1;
+  optional string stdout = 2;
+  optional string stderr = 3;
+  optional int32 exit_code = 4;
 }
 
 service VmmService {
@@ -41,7 +42,6 @@ message RunVmmRequest {
   Language language = 2;
   string code = 3;
   LogLevel log_level = 4;
-
 }
 
 message RunVmmResponse {

--- a/src/agent/src/agents/mod.rs
+++ b/src/agent/src/agents/mod.rs
@@ -91,6 +91,7 @@ mod process_utils {
     pub async fn send_stdout_to_tx(
         stdout: ChildStdout,
         tx: mpsc::Sender<AgentOutput>,
+        stage: Option<Stage>,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             let reader = BufReader::new(stdout);
@@ -99,7 +100,7 @@ mod process_utils {
             while let Ok(Some(line)) = reader_lines.next_line().await {
                 let _ = tx
                     .send(AgentOutput {
-                        stage: Stage::Running,
+                        stage: stage.unwrap_or(Stage::Running),
                         stdout: Some(line),
                         stderr: None,
                         exit_code: None,
@@ -113,6 +114,7 @@ mod process_utils {
     pub async fn send_stderr_to_tx(
         stderr: ChildStderr,
         tx: mpsc::Sender<AgentOutput>,
+        stage: Option<Stage>,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             let reader = BufReader::new(stderr);
@@ -121,7 +123,7 @@ mod process_utils {
             while let Ok(Some(line)) = reader_lines.next_line().await {
                 let _ = tx
                     .send(AgentOutput {
-                        stage: Stage::Running,
+                        stage: stage.unwrap_or(Stage::Running),
                         stdout: Some(line),
                         stderr: None,
                         exit_code: None,

--- a/src/agent/src/agents/mod.rs
+++ b/src/agent/src/agents/mod.rs
@@ -1,9 +1,12 @@
-use crate::{AgentError, AgentResult};
+use crate::{
+    agent::{execute_response::Stage, ExecuteResponse},
+    AgentError, AgentResult,
+};
 use async_trait::async_trait;
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 
 #[cfg(feature = "debug-agent")]
 pub mod debug;
@@ -11,15 +14,33 @@ pub mod rust;
 
 #[derive(Debug, Clone)]
 pub struct AgentOutput {
-    pub exit_code: i32,
-    pub stdout: String,
-    pub stderr: String,
+    pub stage: Stage,
+    pub stdout: Option<String>,
+    pub stderr: Option<String>,
+    pub exit_code: Option<i32>,
+}
+
+impl From<AgentOutput> for ExecuteResponse {
+    fn from(value: AgentOutput) -> Self {
+        Self {
+            stage: value.stage as i32,
+            stdout: value.stdout,
+            stderr: value.stderr,
+            exit_code: value.exit_code,
+        }
+    }
 }
 
 #[async_trait]
 pub trait Agent {
-    async fn prepare(&self, child_processes: Arc<Mutex<HashSet<u32>>>) -> AgentResult<AgentOutput>;
-    async fn run(&self, child_processes: Arc<Mutex<HashSet<u32>>>) -> AgentResult<AgentOutput>;
+    async fn prepare(
+        &self,
+        child_processes: Arc<Mutex<HashSet<u32>>>,
+    ) -> AgentResult<mpsc::Receiver<AgentOutput>>;
+    async fn run(
+        &self,
+        child_processes: Arc<Mutex<HashSet<u32>>>,
+    ) -> AgentResult<mpsc::Receiver<AgentOutput>>;
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -52,6 +73,93 @@ impl TryFrom<&str> for Language {
                 "Invalid language: {}",
                 value
             ))),
+        }
+    }
+}
+
+mod process_utils {
+    use super::AgentOutput;
+    use crate::agent::execute_response::Stage;
+    use tokio::{
+        io::{AsyncBufReadExt, BufReader},
+        process::{ChildStderr, ChildStdout},
+        sync::mpsc,
+    };
+
+    /// Spawn a tokio thread and send each line of `stdout`` to the `tx` given as a parameter.
+    pub async fn send_stdout_to_tx(stdout: ChildStdout, tx: mpsc::Sender<AgentOutput>) {
+        tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut reader_lines = reader.lines();
+
+            while let Ok(Some(line)) = reader_lines.next_line().await {
+                println!("Got line from stdout: {:?}", line);
+
+                let _ = tx
+                    .send(AgentOutput {
+                        stage: Stage::Running,
+                        stdout: Some(line),
+                        stderr: None,
+                        exit_code: None,
+                    })
+                    .await;
+            }
+        });
+    }
+
+    /// Same as [`send_stdout_to_tx`].
+    pub async fn send_stderr_to_tx(stderr: ChildStderr, tx: mpsc::Sender<AgentOutput>) {
+        tokio::spawn(async move {
+            let reader = BufReader::new(stderr);
+            let mut reader_lines = reader.lines();
+
+            while let Ok(Some(line)) = reader_lines.next_line().await {
+                println!("Got line from stderr: {:?}", line);
+
+                let _ = tx
+                    .send(AgentOutput {
+                        stage: Stage::Running,
+                        stdout: Some(line),
+                        stderr: None,
+                        exit_code: None,
+                    })
+                    .await;
+            }
+        });
+    }
+
+    /// Function to wait for the `child` to finish and send the result to the `tx` given as a parameter.
+    pub async fn send_exit_status_to_tx(
+        child: &mut tokio::process::Child,
+        tx: mpsc::Sender<AgentOutput>,
+    ) -> Result<(), ()> {
+        let exit_status = child.wait().await;
+
+        match exit_status {
+            Ok(code) => {
+                let _ = tx
+                    .send(AgentOutput {
+                        stage: Stage::Done,
+                        stdout: None,
+                        stderr: None,
+                        exit_code: code.code(),
+                    })
+                    .await;
+
+                Ok(())
+            }
+            Err(e) => {
+                let _ = tx
+                    .send(AgentOutput {
+                        stage: Stage::Failed,
+                        stdout: None,
+                        stderr: Some(e.to_string()),
+                        exit_code: None,
+                    })
+                    .await;
+
+                Err(())
+            }
         }
     }
 }

--- a/src/agent/src/lib.rs
+++ b/src/agent/src/lib.rs
@@ -1,4 +1,3 @@
-use agents::AgentOutput;
 use std::fmt;
 
 mod agents;
@@ -9,7 +8,8 @@ pub enum AgentError {
     OpenConfigFileError(std::io::Error),
     ParseConfigError(toml::de::Error),
     InvalidLanguage(String),
-    BuildFailed(AgentOutput),
+    BuildNotifier,
+    BuildFailed,
 }
 
 impl fmt::Display for AgentError {
@@ -17,8 +17,9 @@ impl fmt::Display for AgentError {
         match self {
             AgentError::OpenConfigFileError(e) => write!(f, "Failed to open config file: {}", e),
             AgentError::ParseConfigError(e) => write!(f, "Failed to parse config file: {}", e),
-            AgentError::BuildFailed(output) => write!(f, "Build failed: {:?}", output),
             AgentError::InvalidLanguage(e) => write!(f, "Invalid language: {}", e),
+            AgentError::BuildNotifier => write!(f, "Could not get notification from build notifier"),
+            AgentError::BuildFailed => write!(f, "Build has failed"),
         }
     }
 }

--- a/src/agent/src/lib.rs
+++ b/src/agent/src/lib.rs
@@ -18,7 +18,9 @@ impl fmt::Display for AgentError {
             AgentError::OpenConfigFileError(e) => write!(f, "Failed to open config file: {}", e),
             AgentError::ParseConfigError(e) => write!(f, "Failed to parse config file: {}", e),
             AgentError::InvalidLanguage(e) => write!(f, "Invalid language: {}", e),
-            AgentError::BuildNotifier => write!(f, "Could not get notification from build notifier"),
+            AgentError::BuildNotifier => {
+                write!(f, "Could not get notification from build notifier")
+            }
             AgentError::BuildFailed => write!(f, "Build has failed"),
         }
     }

--- a/src/agent/src/workload/service.rs
+++ b/src/agent/src/workload/service.rs
@@ -1,10 +1,10 @@
 use super::runner::Runner;
-use crate::agent::{self, execute_response::Stage, ExecuteRequest, ExecuteResponse, SignalRequest};
+use crate::agent::{self, ExecuteRequest, ExecuteResponse, SignalRequest};
 use agent::workload_runner_server::WorkloadRunner;
 use once_cell::sync::Lazy;
 use std::collections::HashSet;
 use std::{process, sync::Arc};
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response};
 
@@ -20,30 +20,21 @@ impl WorkloadRunner for WorkloadRunnerService {
     type ExecuteStream = ReceiverStream<std::result::Result<ExecuteResponse, tonic::Status>>;
 
     async fn execute(&self, req: Request<ExecuteRequest>) -> Result<Self::ExecuteStream> {
-        let (tx, rx) = tokio::sync::mpsc::channel(4);
-
-        let execute_request = req.into_inner();
-
-        let runner = Runner::new_from_execute_request(execute_request, CHILD_PROCESSES.clone())
+        let runner = Runner::new_from_execute_request(req.into_inner(), CHILD_PROCESSES.clone())
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
-        let res = runner
+        let mut run_rx = runner
             .run()
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
-        let _ = tx
-            .send(Ok(ExecuteResponse {
-                stage: Stage::Done as i32,
-                stdout: res.stdout,
-                stderr: res.stderr,
-                exit_code: res.exit_code,
-            }))
-            .await
-            .map_err(|e| {
-                println!("Failed to send response: {:?}", e);
-                tonic::Status::internal("Failed to send response")
-            })?;
+        let (tx, rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            while let Some(agent_output) = run_rx.recv().await {
+                println!("Sending to the gRPC client: {:?}", agent_output);
+                let _ = tx.send(Ok(agent_output.into())).await;
+            }
+        });
 
         Ok(Response::new(ReceiverStream::new(rx)))
     }

--- a/src/agent/src/workload/service.rs
+++ b/src/agent/src/workload/service.rs
@@ -23,14 +23,14 @@ impl WorkloadRunner for WorkloadRunnerService {
         let runner = Runner::new_from_execute_request(req.into_inner(), CHILD_PROCESSES.clone())
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
-        let mut run_rx = runner
+        let mut runner_rx = runner
             .run()
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
-        let (tx, rx) = mpsc::channel(1);
+        let (tx, rx) = mpsc::channel(10);
         tokio::spawn(async move {
-            while let Some(agent_output) = run_rx.recv().await {
+            while let Some(agent_output) = runner_rx.recv().await {
                 println!("Sending to the gRPC client: {:?}", agent_output);
                 let _ = tx.send(Ok(agent_output.into())).await;
             }

--- a/src/api/src/service.rs
+++ b/src/api/src/service.rs
@@ -1,5 +1,8 @@
 use crate::client::{
-    vmmorchestrator::{execute_response::Stage, ExecuteResponse, RunVmmRequest, ShutdownVmRequest, ShutdownVmResponse},
+    vmmorchestrator::{
+        execute_response::Stage, ExecuteResponse, RunVmmRequest, ShutdownVmRequest,
+        ShutdownVmResponse,
+    },
     VmmClient,
 };
 use actix_web::{post, web, HttpRequest, HttpResponse, Responder};

--- a/src/cli/examples/main.rs
+++ b/src/cli/examples/main.rs
@@ -17,5 +17,10 @@ fn fibonacci(n: u32) -> u64 {
 
 fn main() {
     let n = 10;
-    println!("Fibonacci number at position {} is: {}", n, fibonacci(n));
+
+    for i in 0..=10 {
+        println!("🚀 Loop {}", i);
+        println!("Fibonacci number at position {} is: {}", n, fibonacci(n));
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
 }

--- a/src/vmm/src/grpc/server.rs
+++ b/src/vmm/src/grpc/server.rs
@@ -250,6 +250,7 @@ impl VmmServiceTrait for VmmService {
                 // Process each message as it arrives
                 while let Some(response) = response_stream.message().await? {
                     let vmm_response = vmmorchestrator::ExecuteResponse {
+                        stage: response.stage,
                         stdout: response.stdout,
                         stderr: response.stderr,
                         exit_code: response.exit_code,


### PR DESCRIPTION
# What does this PR do?

todo:

- [x] `prepare` stream logs
- [x] `run` stream logs
- [x] fix stream on VMM

I've also updated the protos to be more accurate on the data.
Example: added optional fields because we do not need `exit_code` or output on every message.

Co-author: @noetarbouriech 
