### PR TITLE
feat(fs-gen, vmm): disable compression

### DIFF
--- a/src/fs-gen/src/cli_args.rs
+++ b/src/fs-gen/src/cli_args.rs
@@ -49,6 +49,10 @@ pub struct CliArgs {
     /// Allow invalid TLS certificates
     #[arg(long="insecure", action=ArgAction::SetTrue)]
     pub insecure: bool,
+
+    /// Disable the compression of the final image
+    #[arg(short, long, action=ArgAction::SetTrue)]
+    pub no_compression: bool,
 }
 
 impl CliArgs {

--- a/src/fs-gen/src/main.rs
+++ b/src/fs-gen/src/main.rs
@@ -40,7 +40,11 @@ fn run(args: CliArgs) -> Result<()> {
     // building initramfs
     create_init_file(output_subdir, args.initfile_path)?;
     insert_agent(output_subdir, args.agent_host_path)?;
-    generate_initramfs(output_subdir, Path::new(args.output_file.as_path()))?;
+    generate_initramfs(
+        output_subdir,
+        Path::new(args.output_file.as_path()),
+        !args.no_compression,
+    )?;
 
     // cleanup of temporary directory
     remove_dir_all(args.temp_directory.clone())

--- a/tools/rootfs/mkrootfs.sh
+++ b/tools/rootfs/mkrootfs.sh
@@ -11,7 +11,7 @@ ulimit -Sn 8192
 
 if [ -d fs-gen ]
 then
-    cargo run --bin fs-gen -- $1 $2 -o $3
+    cargo run --bin fs-gen -- $1 $2 -o $3 --no-compression
 else
     echo "Module fs-gen not found"
 fi


### PR DESCRIPTION
# What's in it?

This PR brings the ability to disable compression on the final image, via the `--no-compression` arg.

Additionally, it enables the usage of this argument by vmm.

# Why this PR?

Compression significantly increases startup times. This isn't desired behavior.
